### PR TITLE
Rpi setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ SENSOR_DEVICE_ID=cf79
 # ─── Services (true / false) ─────────────────────────────────
 CLASSIFIER_ENABLED=true
 LLM_ENABLED=true
+LLM_BACKEND=llama-cpp
+# LLM_BACKEND=ollama        # use this for Hailo AI HAT+ / hailo-ollama
+# LLM_MODEL=qwen2:1.5b      # Ollama model name (only when LLM_BACKEND=ollama)
 TTS_ENABLED=true
 REMOTE_SAVE_ENABLED=true
 

--- a/setup.sh
+++ b/setup.sh
@@ -224,6 +224,16 @@ if [[ "$CONFIGURE_ENV" == "true" ]]; then
     prompt_yn "Enable LLM service?" LLM_ENABLED "y"
     env_set .env LLM_ENABLED "$LLM_ENABLED"
 
+    if [[ "$LLM_ENABLED" == "true" ]]; then
+        prompt "LLM backend (llama-cpp / ollama)" LLM_BACKEND "llama-cpp"
+        env_set .env LLM_BACKEND "$LLM_BACKEND"
+        if [[ "$LLM_BACKEND" == "ollama" ]]; then
+            prompt "Ollama model name" LLM_MODEL "qwen2:1.5b"
+            env_set .env LLM_MODEL "$LLM_MODEL"
+            info "Using hailo-ollama — the LLM Docker container will NOT be built"
+        fi
+    fi
+
     prompt_yn "Enable TTS service?" TTS_ENABLED "y"
     env_set .env TTS_ENABLED "$TTS_ENABLED"
 
@@ -316,7 +326,7 @@ header "Phase 4 · Model downloads"
 
 # LLM model
 GGUF_PATH="services/llm/coffee-gguf/coffee-Q4_K_M.gguf"
-if [[ "${LLM_ENABLED:-false}" == "true" ]]; then
+if [[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" != "ollama" ]]; then
     mkdir -p "$(dirname "$GGUF_PATH")"
     if [[ -f "$GGUF_PATH" ]]; then
         ok "LLM model already present ($(du -h "$GGUF_PATH" | cut -f1))"
@@ -338,6 +348,8 @@ if [[ "${LLM_ENABLED:-false}" == "true" ]]; then
             fail "LLM model download failed"
         fi
     fi
+elif [[ "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
+    info "LLM using hailo-ollama — GGUF model not needed"
 else
     info "LLM disabled — skipping model download"
 fi
@@ -395,9 +407,11 @@ else
     info "tts disabled — skipping build"
 fi
 
-if [[ "${LLM_ENABLED:-false}" == "true" ]]; then
+if [[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" != "ollama" ]]; then
     info "Building LLM service (this may take 15–30 min on ARM64)..."
     build_service "llm" "llm"
+elif [[ "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
+    info "LLM using hailo-ollama — skipping Docker build"
 else
     info "llm disabled — skipping build"
 fi
@@ -440,7 +454,7 @@ if [[ "$ENABLE_SYSTEMD" == "true" ]]; then
     # Build the profile flags string for docker compose
     PROFILES=""
     [[ "${CLASSIFIER_ENABLED:-false}"  == "true" ]] && PROFILES="$PROFILES --profile classifier"
-    [[ "${LLM_ENABLED:-false}"         == "true" ]] && PROFILES="$PROFILES --profile llm"
+    [[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" != "ollama" ]] && PROFILES="$PROFILES --profile llm"
     [[ "${TTS_ENABLED:-false}"         == "true" ]] && PROFILES="$PROFILES --profile tts"
     [[ "${REMOTE_SAVE_ENABLED:-false}" == "true" ]] && PROFILES="$PROFILES --profile remote-save"
     PROFILES="${PROFILES# }"  # trim leading space

--- a/start.sh
+++ b/start.sh
@@ -28,7 +28,7 @@ set -a; source .env; set +a
 # ── Build profile flags ─────────────────────────────────────────
 PROFILES=""
 [[ "${CLASSIFIER_ENABLED:-false}"  == "true" ]] && PROFILES="$PROFILES --profile classifier"
-[[ "${LLM_ENABLED:-false}"         == "true" ]] && PROFILES="$PROFILES --profile llm"
+[[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" != "ollama" ]] && PROFILES="$PROFILES --profile llm"
 [[ "${TTS_ENABLED:-false}"         == "true" ]] && PROFILES="$PROFILES --profile tts"
 [[ "${REMOTE_SAVE_ENABLED:-false}" == "true" ]] && PROFILES="$PROFILES --profile remote-save"
 
@@ -57,7 +57,7 @@ if [[ -n "$PROFILES" ]]; then
     # ── Health-check loop ────────────────────────────────────────
     declare -A SVC_HEALTH
     [[ "${CLASSIFIER_ENABLED:-false}"  == "true" ]] && SVC_HEALTH[classifier]="${CLASSIFIER_ENDPOINT:-http://localhost:8001}/health"
-    [[ "${LLM_ENABLED:-false}"         == "true" ]] && SVC_HEALTH[llm]="${LLM_ENDPOINT:-http://localhost:8000}/health"
+    [[ "${LLM_ENABLED:-false}" == "true" ]] && SVC_HEALTH[llm]="${LLM_ENDPOINT:-http://localhost:8000}/health"
     [[ "${TTS_ENABLED:-false}"         == "true" ]] && SVC_HEALTH[tts]="${TTS_ENDPOINT:-http://localhost:5050}/health"
     [[ "${REMOTE_SAVE_ENABLED:-false}" == "true" ]] && SVC_HEALTH[remote-save]="${REMOTE_SAVE_ENDPOINT:-http://localhost:7000}/health"
 

--- a/stop.sh
+++ b/stop.sh
@@ -28,7 +28,7 @@ fi
 
 PROFILES=""
 [[ "${CLASSIFIER_ENABLED:-false}"  == "true" ]] && PROFILES="$PROFILES --profile classifier"
-[[ "${LLM_ENABLED:-false}"         == "true" ]] && PROFILES="$PROFILES --profile llm"
+[[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" != "ollama" ]] && PROFILES="$PROFILES --profile llm"
 [[ "${TTS_ENABLED:-false}"         == "true" ]] && PROFILES="$PROFILES --profile tts"
 [[ "${REMOTE_SAVE_ENABLED:-false}" == "true" ]] && PROFILES="$PROFILES --profile remote-save"
 


### PR DESCRIPTION
This pull request introduces support for selecting the LLM backend (`llama-cpp` or `ollama`) and improves the setup and startup scripts to handle backend-specific configuration, model downloads, service builds, and health checks. The changes ensure that when using the `ollama` backend (e.g., Hailo AI HAT+), unnecessary model downloads and Docker builds are skipped, and health checks are more robust.

LLM backend selection and configuration:

* Added `LLM_BACKEND` and optional `LLM_MODEL` variables to `.env.example` for backend selection and model naming.
* Updated `setup.sh` to prompt for LLM backend and Ollama model name during environment configuration.

Backend-specific setup and build logic:

* Modified model download and build steps in `setup.sh` to skip GGUF model download and Docker build when `LLM_BACKEND` is set to `ollama`. [[1]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L319-R329) [[2]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R351-R352) [[3]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L398-R414)

Service profile and startup logic:

* Updated `setup.sh`, `start.sh`, and `stop.sh` to only include the `llm` profile when `LLM_BACKEND` is not `ollama`. [[1]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L443-R457) [[2]](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5L31-R31) [[3]](diffhunk://#diff-7ef9ea36ec1f7ad4fc62b42f6f482bf3f05013fdf11844741428a87ccd9ba6c0L31-R31)
* Changed Docker compose commands to always use `--build` for up actions in both scripts and systemd unit file. [[1]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L460-R477) [[2]](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5L55-R80)

Health check improvements:

* Replaced port-based health checks with endpoint-based checks in `start.sh`, improving reliability and flexibility.