### PR TITLE
fix: sensor reconnection with retry, watchdog, and USB autosuspend

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -43,18 +43,64 @@ _sensor_started = False
 _shutdown_event: asyncio.Event | None = None
 
 
+# Sensor watchdog constants
+_SENSOR_MAX_RESTARTS = 5
+_SENSOR_RESTART_WINDOW = 300  # seconds
+
+
 async def _auto_trigger_loop():
     """Poll the PicoQuake recording_flag and run the pipeline on vibration."""
     from sensor.picoquake_reader import picoquake_reader
 
     logger.info("Auto-trigger loop started (polling every 500 ms)")
     _prev_flag = 0
+    _restart_times: list[float] = []  # track restart timestamps for rate-limiting
     while True:
         try:
             await asyncio.sleep(0.5)
 
             if not config.SENSOR_AUTO_TRIGGER:
                 continue
+
+            # ── Watchdog: auto-restart dead sensor ────────────────
+            if not picoquake_reader.is_running and config.SENSOR_MODE == "picoquake":
+                import time as _time
+                now = _time.monotonic()
+                # Prune restart timestamps outside the rate-limit window
+                _restart_times = [t for t in _restart_times
+                                  if now - t < _SENSOR_RESTART_WINDOW]
+                if len(_restart_times) >= _SENSOR_MAX_RESTARTS:
+                    # Already restarted too many times recently — back off
+                    logger.error(
+                        "Sensor has been restarted %d times in the last %ds "
+                        "— not attempting again. Manual intervention required.",
+                        len(_restart_times), _SENSOR_RESTART_WINDOW,
+                    )
+                    _broadcast({"type": "status",
+                                "message": "Sensor offline — max restarts exceeded. "
+                                           "Check hardware and restart manually."})
+                    await asyncio.sleep(30)  # long sleep before re-checking
+                    continue
+
+                logger.warning("Sensor acquisition not running — attempting restart…")
+                _broadcast({"type": "status",
+                            "message": "Sensor connection lost — reconnecting…"})
+                try:
+                    picoquake_reader.stop()  # clean up stale state / shared memory
+                    loop = asyncio.get_event_loop()
+                    await loop.run_in_executor(None, _start_sensor)
+                    _restart_times.append(now)
+                    logger.info("Sensor restarted successfully (attempt %d/%d in window)",
+                                len(_restart_times), _SENSOR_MAX_RESTARTS)
+                    _broadcast({"type": "status",
+                                "message": "Sensor reconnected successfully."})
+                except Exception:
+                    logger.exception("Sensor restart failed — will retry in 10s")
+                    _broadcast({"type": "status",
+                                "message": "Sensor restart failed — retrying…"})
+                await asyncio.sleep(10)
+                continue
+
             if not picoquake_reader.is_running:
                 continue
             if picoquake_reader._ring is None:

--- a/app/sensor/picoquake_acq.py
+++ b/app/sensor/picoquake_acq.py
@@ -276,15 +276,7 @@ def main_acquisition():
     ring = SharedRingBuffer(ring_samples, create=True)
     ring.status = 0
 
-    logger.info("Connecting to PicoQuake device '%s'…", args.device)
-    try:
-        import picoquake
-        device = picoquake.PicoQuake(args.device)
-    except Exception as exc:
-        logger.error("Could not connect to device: %s", exc)
-        ring.status = 2
-        ring.cleanup()
-        sys.exit(1)
+    import picoquake
 
     _ACC_RANGE_MAP = {
         2: picoquake.AccRange.g_2,
@@ -305,107 +297,169 @@ def main_acquisition():
         734: picoquake.Filter.hz_734,
     }
 
-    device.configure(
-        sample_rate=_rate_enum(args.rate),
-        filter_hz=_FILTER_MAP[args.filter_hz],
-        acc_range=_ACC_RANGE_MAP[args.acc_range],
-        gyro_range=_GYRO_RANGE_MAP[args.gyro_range],
-    )
+    # ── Retry / reconnection constants ───────────────────────────
+    MAX_RETRIES = 5
+    INITIAL_RETRY_DELAY = 3.0
+    MAX_RETRY_DELAY = 30.0
 
-    logger.info("Device configured: %d Hz | acc_range=%dg | gyro_range=%d dps | filter=%d Hz | threshold=%.1fg | duration=%ds",
-                args.rate, args.acc_range, args.gyro_range, args.filter_hz, args.threshold, args.duration)
-    logger.info("Starting continuous acquisition…")
+    def _connect_and_configure():
+        """Connect to the PicoQuake sensor and configure it. Returns device."""
+        logger.info("Connecting to PicoQuake device '%s'…", args.device)
+        dev = picoquake.PicoQuake(args.device)
+        dev.configure(
+            sample_rate=_rate_enum(args.rate),
+            filter_hz=_FILTER_MAP[args.filter_hz],
+            acc_range=_ACC_RANGE_MAP[args.acc_range],
+            gyro_range=_GYRO_RANGE_MAP[args.gyro_range],
+        )
+        logger.info("Device configured: %d Hz | acc_range=%dg | gyro_range=%d dps | filter=%d Hz | threshold=%.1fg | duration=%ds",
+                    args.rate, args.acc_range, args.gyro_range, args.filter_hz, args.threshold, args.duration)
+        return dev
 
-    device.start_continuos()
-    ring.status = 1
-
-    t0 = time.monotonic()
-    last_log = t0
-    batch: list[list[float]] = []
-    samples_since_log = 0
-
-    # Auto-trigger state
-    rms_window_size = max(1, int(args.rate * args.rms_window))  # configurable RMS window
-    recent_accel: list[float] = []
-    recording_count = 0  # samples captured since recording started
-
+    # ── Initial connection ────────────────────────────────────────
     try:
-        while True:
-            frames = device.read(num=batch_size, timeout=1.0)
-            if not frames:
-                continue
+        device = _connect_and_configure()
+    except Exception as exc:
+        logger.error("Could not connect to device: %s", exc)
+        ring.status = 2
+        ring.cleanup()
+        sys.exit(1)
 
-            now = time.monotonic()
+    # ── Acquisition with retry on connection loss ────────────────
+    retry_delay = INITIAL_RETRY_DELAY
+    attempt = 0
 
-            for frame in frames:
-                sample_idx = ring.sample_counter + len(batch)
-                t = sample_idx * sample_interval
-                row = [t, frame.acc_x, frame.acc_y, frame.acc_z,
-                       frame.gyro_x, frame.gyro_y, frame.gyro_z]
-                batch.append(row)
+    while True:
+        logger.info("Starting continuous acquisition…")
+        device.start_continuos()
+        ring.status = 1
 
-                # Track accel magnitude for auto-trigger
-                mag = (frame.acc_x**2 + frame.acc_y**2 + frame.acc_z**2) ** 0.5
-                recent_accel.append(mag)
-                if len(recent_accel) > rms_window_size:
-                    recent_accel.pop(0)
+        t0 = time.monotonic()
+        last_log = t0
+        batch: list[list[float]] = []
+        samples_since_log = 0
 
-            samples_since_log += len(frames)
+        # Auto-trigger state
+        rms_window_size = max(1, int(args.rate * args.rms_window))  # configurable RMS window
+        recent_accel: list[float] = []
+        recording_count = 0  # samples captured since recording started
 
-            # Flush batch to ring
-            if len(batch) >= 50 or (now - t0) - (ring.sample_counter * sample_interval) > 0.1:
+        try:
+            while True:
+                frames = device.read(num=batch_size, timeout=1.0)
+                if not frames:
+                    continue
+
+                now = time.monotonic()
+                # Reset retry state on successful reads
+                attempt = 0
+                retry_delay = INITIAL_RETRY_DELAY
+
+                for frame in frames:
+                    sample_idx = ring.sample_counter + len(batch)
+                    t = sample_idx * sample_interval
+                    row = [t, frame.acc_x, frame.acc_y, frame.acc_z,
+                           frame.gyro_x, frame.gyro_y, frame.gyro_z]
+                    batch.append(row)
+
+                    # Track accel magnitude for auto-trigger
+                    mag = (frame.acc_x**2 + frame.acc_y**2 + frame.acc_z**2) ** 0.5
+                    recent_accel.append(mag)
+                    if len(recent_accel) > rms_window_size:
+                        recent_accel.pop(0)
+
+                samples_since_log += len(frames)
+
+                # Flush batch to ring
+                if len(batch) >= 50 or (now - t0) - (ring.sample_counter * sample_interval) > 0.1:
+                    ring.write_samples(batch)
+                    batch.clear()
+
+                # ── Auto-trigger logic ───────────────────────────────
+                flag = ring.recording_flag
+
+                if flag == 0 and len(recent_accel) >= rms_window_size:
+                    # Check RMS threshold
+                    rms = (sum(a * a for a in recent_accel) / len(recent_accel)) ** 0.5
+                    if rms > args.threshold:
+                        logger.info("Vibration detected! RMS=%.2fg > threshold=%.1fg → recording %ds",
+                                    rms, args.threshold, args.duration)
+                        ring.recording_start_idx = ring.write_idx
+                        ring.recording_samples = record_samples
+                        ring.recording_flag = 1
+                        recording_count = 0
+
+                elif flag == 1:
+                    # Manual trigger (set by app) also enters here
+                    if ring.recording_start_idx == 0:
+                        # App just set flag=1 but didn't set start idx yet
+                        ring.recording_start_idx = ring.write_idx
+                        ring.recording_samples = record_samples
+
+                    recording_count = ring.write_idx - ring.recording_start_idx
+                    if recording_count >= ring.recording_samples:
+                        logger.info("Recording complete (%d samples captured)", recording_count)
+                        ring.recording_flag = 2
+
+                # flag == 2: capture ready, waiting for app to reset to 0
+
+                # ── Periodic logging ─────────────────────────────────
+                if now - last_log >= 5.0:
+                    actual_rate = samples_since_log / (now - last_log)
+                    rms = (sum(a * a for a in recent_accel) / max(1, len(recent_accel))) ** 0.5
+                    logger.info("samples=%d  rate=%.1f Hz  drops=%d  rms=%.2fg  recording=%d",
+                                ring.sample_counter, actual_rate, ring.drop_counter, rms, flag)
+                    last_log = now
+                    samples_since_log = 0
+
+        except KeyboardInterrupt:
+            logger.info("Stopping acquisition (Ctrl+C)")
+            break  # exit retry loop — clean shutdown
+
+        except Exception as exc:
+            # Flush any pending samples
+            if batch:
                 ring.write_samples(batch)
                 batch.clear()
 
-            # ── Auto-trigger logic ───────────────────────────────
-            flag = ring.recording_flag
+            attempt += 1
+            logger.error("Acquisition error (attempt %d/%d): %s", attempt, MAX_RETRIES, exc)
 
-            if flag == 0 and len(recent_accel) >= rms_window_size:
-                # Check RMS threshold
-                rms = (sum(a * a for a in recent_accel) / len(recent_accel)) ** 0.5
-                if rms > args.threshold:
-                    logger.info("Vibration detected! RMS=%.2fg > threshold=%.1fg → recording %ds",
-                                rms, args.threshold, args.duration)
-                    ring.recording_start_idx = ring.write_idx
-                    ring.recording_samples = record_samples
-                    ring.recording_flag = 1
-                    recording_count = 0
+            # Try to stop the device gracefully
+            try:
+                device.stop()
+            except Exception:
+                pass
 
-            elif flag == 1:
-                # Manual trigger (set by app) also enters here
-                if ring.recording_start_idx == 0:
-                    # App just set flag=1 but didn't set start idx yet
-                    ring.recording_start_idx = ring.write_idx
-                    ring.recording_samples = record_samples
+            if attempt >= MAX_RETRIES:
+                logger.error("Max retries (%d) exhausted — giving up", MAX_RETRIES)
+                ring.status = 2
+                break
 
-                recording_count = ring.write_idx - ring.recording_start_idx
-                if recording_count >= ring.recording_samples:
-                    logger.info("Recording complete (%d samples captured)", recording_count)
-                    ring.recording_flag = 2
+            # Exponential backoff before reconnecting
+            logger.info("Retrying in %.0fs…", retry_delay)
+            ring.status = 0  # signal "stopped" while we reconnect
+            time.sleep(retry_delay)
+            retry_delay = min(retry_delay * 2, MAX_RETRY_DELAY)
 
-            # flag == 2: capture ready, waiting for app to reset to 0
+            # Reconnect
+            try:
+                device = _connect_and_configure()
+            except Exception as reconn_exc:
+                logger.error("Reconnection failed: %s", reconn_exc)
+                if attempt >= MAX_RETRIES:
+                    ring.status = 2
+                    break
+                continue  # back to top of retry loop
 
-            # ── Periodic logging ─────────────────────────────────
-            if now - last_log >= 5.0:
-                actual_rate = samples_since_log / (now - last_log)
-                rms = (sum(a * a for a in recent_accel) / max(1, len(recent_accel))) ** 0.5
-                logger.info("samples=%d  rate=%.1f Hz  drops=%d  rms=%.2fg  recording=%d",
-                            ring.sample_counter, actual_rate, ring.drop_counter, rms, flag)
-                last_log = now
-                samples_since_log = 0
-
-    except KeyboardInterrupt:
-        logger.info("Stopping acquisition (Ctrl+C)")
-    except Exception as exc:
-        logger.error("Acquisition error: %s", exc)
-        ring.status = 2
-    finally:
-        if batch:
-            ring.write_samples(batch)
+    # ── Final cleanup ────────────────────────────────────────────
+    try:
         device.stop()
-        ring.status = 0
-        logger.info("Total samples acquired: %d", ring.sample_counter)
-        ring.close()
+    except Exception:
+        pass
+    ring.status = 0
+    logger.info("Total samples acquired: %d", ring.sample_counter)
+    ring.cleanup()
 
 
 if __name__ == "__main__":

--- a/setup.sh
+++ b/setup.sh
@@ -424,15 +424,26 @@ header "Phase 6 · USB device setup"
 if [[ "${SENSOR_MODE:-mock}" == "picoquake" ]]; then
     UDEV_RULE='/etc/udev/rules.d/99-picoquake.rules'
     RULE_CONTENT='SUBSYSTEM=="tty", ATTRS{idProduct}=="000a", ATTRS{idVendor}=="2e8a", MODE="0666", SYMLINK+="picoquake"'
+    # Disable USB autosuspend for the PicoQuake to prevent connection drops
+    AUTOSUSPEND_RULE='/etc/udev/rules.d/99-picoquake-power.rules'
+    AUTOSUSPEND_CONTENT='ACTION=="add", SUBSYSTEM=="usb", ATTRS{idProduct}=="000a", ATTRS{idVendor}=="2e8a", TEST=="power/control", ATTR{power/control}="on"'
 
     if [[ -f "$UDEV_RULE" ]]; then
         ok "udev rule already installed"
     else
         echo "$RULE_CONTENT" | sudo tee "$UDEV_RULE" > /dev/null
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger
         ok "udev rule installed at $UDEV_RULE"
     fi
+
+    if [[ -f "$AUTOSUSPEND_RULE" ]]; then
+        ok "USB autosuspend rule already installed"
+    else
+        echo "$AUTOSUSPEND_CONTENT" | sudo tee "$AUTOSUSPEND_RULE" > /dev/null
+        ok "USB autosuspend disabled for PicoQuake"
+    fi
+
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger
 
     if ls /dev/ttyACM* 1>/dev/null 2>&1; then
         ok "PicoQuake USB device detected"


### PR DESCRIPTION
## Problem

PicoQuake USB sensor drops with `Connection lost, device not responding` after extended runtime (~1.5 days on Raspberry Pi). After the error:

1. The acquisition subprocess exits permanently
2. Shared memory segments leak (`/picoquake_meta`, `/picoquake_ring`)
3. The auto-trigger loop silently spins doing nothing (`is_running` returns `False`  `continue`)
4. Uvicorn stays alive so systemd never restarts anything
5. **The app appears healthy but is completely non-functional for sensor operations**

## Root Cause

- **USB autosuspend** (likely trigger): Linux kernel suspends idle USB devices by default. A brief I/O pause during GC, thermal throttling, or scheduling can cause the PicoQuake to become unresponsive.
- **No retry logic** in acquisition subprocess  any exception from `device.read()` is fatal.
- **No watchdog** in the parent process  dead subprocess is never restarted.
- **Shared memory leak**  `ring.close()` detaches but doesn't `unlink()` the segments.

## Changes

### `app/sensor/picoquake_acq.py`  Retry loop with exponential backoff
- Wrap the inner acquisition `while True` loop in an outer retry loop (5 retries, 3s30s exponential backoff, capped at 30s)
- On `ConnectionError` or any exception: flush pending samples, stop device, sleep with backoff, reconnect + reconfigure, resume
- Reset retry counter on every successful `device.read()`
- **Fix shared memory leak**: `ring.cleanup()` (close + unlink) instead of `ring.close()` (close only)

### `app/main.py`  Watchdog auto-restart in auto-trigger loop
- When `picoquake_reader.is_running` returns `False`, the loop now calls `picoquake_reader.stop()`  `_start_sensor()` to respawn the subprocess
- Rate-limited to 5 restarts per 5-minute window to prevent restart storms if hardware is truly broken
- Broadcasts reconnection status updates to SSE clients (kiosk UI)

### `setup.sh`  USB autosuspend prevention
- Add a second udev rule (`99-picoquake-power.rules`) that sets `ATTR{power/control}=on` for PicoQuake USB devices
- Prevents the kernel from ever suspending the sensor, addressing the most likely root trigger

## Defense in Depth

| Layer | What | Where |
|-------|------|-------|
| 1. Prevention | Disable USB autosuspend | udev rule |
| 2. Subprocess retry | Reconnect on transient USB glitches | `picoquake_acq.py` |
| 3. Parent watchdog | Restart entire subprocess if retry exhausted | `main.py` |
| 4. Rate limiting | Stop restart storms on hardware failure | `main.py` |

## Verification

- **USB autosuspend**: After deploying new udev rule, `cat /sys/bus/usb/devices/*/power/control` should show `on` for PicoQuake
- **Retry test**: Unplug/replug USB cable  logs should show retry attempts and successful reconnection
- **Shared memory**: After crash, `ls /dev/shm/picoquake*` should be empty
- **Watchdog test**: Kill the acquisition subprocess PID  parent should detect and restart within 10s
- **Rate limit test**: Kill subprocess 5+ times rapidly  should stop restarting and log manual intervention required