### PR TITLE
fix: auto-trigger recording_flag stuck at 2  never re-arms

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -108,6 +108,14 @@ async def _auto_trigger_loop():
 
             flag = picoquake_reader._ring.recording_flag
 
+            # Guard: reset stale recording_flag=2 that was never consumed
+            # (e.g. after exception recovery, startup race, or manual brew)
+            if flag == 2:
+                logger.warning("Auto-trigger: found stale recording_flag=2 — resetting to 0")
+                picoquake_reader._ring.recording_flag = 0
+                _prev_flag = 0
+                continue
+
             # Detect recording start (flag transitions 0→1) and stream data live
             if flag == 1 and _prev_flag == 0:
                 logger.info("Auto-trigger: recording started (capturing %ds)…",
@@ -115,42 +123,47 @@ async def _auto_trigger_loop():
                 _broadcast({"type": "status",
                             "message": "Vibration detected! Recording sensor data…"})
 
-                # Stream sensor data to the kiosk chart in real time.
-                # stream_capture() yields batches until flag==2, then resets flag→0.
-                all_sensor_data: list[dict[str, float]] = []
-                t0: float | None = None
-                async for batch in picoquake_reader.stream_capture(batch_interval=0.3, auto_reset=False):
-                    if not batch:
-                        continue
-                    # Normalise elapsed_s so chart starts at t=0
-                    if t0 is None:
-                        t0 = batch[0].get("elapsed_s", 0.0)
-                    for sample in batch:
-                        sample["elapsed_s"] = sample.get("elapsed_s", 0.0) - t0
-                    all_sensor_data.extend(batch)
-                    # Downsample large batches for the SSE payload
-                    step = max(1, len(batch) // 30)
-                    _broadcast({"type": "sensor_data", "data": batch[::step]})
+                try:
+                    # Stream sensor data to the kiosk chart in real time.
+                    # stream_capture() yields batches until flag==2, then resets flag→0.
+                    all_sensor_data: list[dict[str, float]] = []
+                    t0: float | None = None
+                    async for batch in picoquake_reader.stream_capture(batch_interval=0.3, auto_reset=False):
+                        if not batch:
+                            continue
+                        # Normalise elapsed_s so chart starts at t=0
+                        if t0 is None:
+                            t0 = batch[0].get("elapsed_s", 0.0)
+                        for sample in batch:
+                            sample["elapsed_s"] = sample.get("elapsed_s", 0.0) - t0
+                        all_sensor_data.extend(batch)
+                        # Downsample large batches for the SSE payload
+                        step = max(1, len(batch) // 30)
+                        _broadcast({"type": "sensor_data", "data": batch[::step]})
 
-                # Recording complete — run classifier → llm → tts pipeline
-                # with pre-collected sensor data (no re-read required).
-                logger.info("Auto-trigger: streaming done (%d samples), running pipeline…",
-                            len(all_sensor_data))
-                _broadcast({"type": "status", "message": "Recording complete. Running pipeline…"})
+                    # Recording complete — run classifier → llm → tts pipeline
+                    # with pre-collected sensor data (no re-read required).
+                    logger.info("Auto-trigger: streaming done (%d samples), running pipeline…",
+                                len(all_sensor_data))
+                    _broadcast({"type": "status", "message": "Recording complete. Running pipeline…"})
 
-                def _progress(msg: str) -> None:
-                    _broadcast({"type": "status", "message": msg})
+                    def _progress(msg: str) -> None:
+                        _broadcast({"type": "status", "message": msg})
 
-                result = await run_pipeline(sensor_data=all_sensor_data, on_progress=_progress)
-                result.pop("sensor_data", None)  # already streamed to chart
+                    result = await run_pipeline(sensor_data=all_sensor_data, on_progress=_progress)
+                    result.pop("sensor_data", None)  # already streamed to chart
 
-                # Re-arm the sensor now that the pipeline is done
-                if picoquake_reader._ring is not None:
-                    picoquake_reader._ring.recording_flag = 0
-                    logger.info("Auto-trigger: sensor re-armed")
+                    _broadcast({"type": "result", "data": result})
+                    logger.info("Auto-trigger pipeline complete: %s", result.get("label"))
 
-                _broadcast({"type": "result", "data": result})
-                logger.info("Auto-trigger pipeline complete: %s", result.get("label"))
+                finally:
+                    # ALWAYS re-arm the sensor, even if the pipeline fails.
+                    # Without this, recording_flag stays at 2 and the
+                    # acquisition subprocess never auto-triggers again.
+                    if picoquake_reader._ring is not None:
+                        picoquake_reader._ring.recording_flag = 0
+                        logger.info("Auto-trigger: sensor re-armed")
+
                 _prev_flag = 0
                 continue
 


### PR DESCRIPTION
﻿## Problem

Auto-trigger detects vibration and captures data **once**, but never triggers again. The sensor appears healthy and manual brew from the admin panel works fine. Only affects auto-trigger mode on the Pi.

## Root Cause

The `recording_flag` in shared memory gets permanently stuck at `2` (capture ready), which prevents the acquisition subprocess from ever firing another auto-trigger.

### How the deadlock happens

1. Acquisition subprocess detects vibration RMS > threshold, sets `recording_flag = 1`
2. After `duration` seconds of recording, sets `recording_flag = 2`
3. `_auto_trigger_loop` in main.py picks up `flag=1`, streams data, then calls `run_pipeline()`
4. If **any exception** occurs between `stream_capture()` finishing (flag=2) and the explicit `recording_flag = 0` reset, the flag stays at 2
5. The `except Exception` handler resets `_prev_flag` but **not** `recording_flag`
6. Acquisition subprocess sees `flag=2`, skips RMS threshold check, never auto-triggers again
7. System is permanently deadlocked until manual restart

### Why it reliably happens on the Pi

- `SENSOR_VIBRATION_THRESHOLD: 1.0118` barely above resting gravity RMS (~1.0g), so the sensor triggers almost immediately on any noise
- `LLM_ENABLED: false` pipeline reaches the LLM step which returns None, potentially cascading into downstream issues
- Any transient network/service error during the pipeline permanently kills auto-trigger

## Fix

### A. try/finally guard around pipeline processing

Wraps the entire stream_capture + run_pipeline + broadcast block in try/finally so recording_flag is ALWAYS reset to 0, even on exception.

### B. Stale flag==2 guard

Added a check at the top of the polling loop that detects and resets stale recording_flag=2. This recovers from edge cases: startup races, exception recovery, or interference from manual brews.

## Verification

- Trigger vibration, pipeline runs, sensor re-arms, trigger again, pipeline runs again
- Kill a downstream service (e.g. classifier), pipeline fails, sensor still re-arms
- Restart app while acquisition subprocess has flag=2, stale flag is cleared on first poll
