### PR TITLE
fix: use local device datetime instead of UTC for LLM timestamps

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -18,7 +18,7 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncGenerator
 
@@ -72,7 +72,7 @@ async def run_pipeline(
         "error": None,
     }
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now().astimezone()
 
     # ── Step 0: Collect sensor data ──────────────────────────────
     try:
@@ -192,7 +192,7 @@ async def run_pipeline_streaming() -> AsyncGenerator[str, None]:
         "error": None,
     }
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now().astimezone()
 
     # ── Step 0: Stream sensor data ───────────────────────────────
     yield _sse("status", {"message": "Collecting sensor data…"})

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -10,7 +10,7 @@ The active backend is selected via ``config.LLM_BACKEND``.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 import httpx
@@ -64,7 +64,7 @@ class LLMClient:
             return None
 
         if timestamp is None:
-            timestamp = datetime.now(timezone.utc)
+            timestamp = datetime.now().astimezone()
 
         # Resolve from config if not explicitly provided
         if tts is None:


### PR DESCRIPTION
## Summary

The LLM service was receiving UTC timestamps, causing the generated coffee statements to reference incorrect day/time for the device's local timezone.

### Changes

Replace \datetime.now(timezone.utc)\ with \datetime.now().astimezone()\ in three locations:

- **\pp/pipeline.py\** line 75 (\un_pipeline\)  timestamp passed to LLM generation
- **\pp/pipeline.py\** line 195 (\un_pipeline_streaming\)  same for streaming pipeline
- **\pp/services/llm_client.py\** line 67  fallback timestamp when none is provided

\datetime.now().astimezone()\ produces a timezone-aware datetime in the device's local timezone. The \.isoformat()\ output includes the local UTC offset (e.g. \+01:00\), and the downstream \parse_timestamp()\ / \_parse_timestamp()\ functions in both the llama-cpp server and ollama adapter already use \strftime\ which will produce correct local weekday and time from the local-aware datetime.

### Files Changed
- \pp/pipeline.py\  two \datetime.now()\ calls updated
- \pp/services/llm_client.py\  one \datetime.now()\ call updated, unused \	imezone\ import removed