### PR TITLE
fix: separate LLM endpoints for llama-cpp and ollama to prevent port conflict

### DIFF
--- a/app/admin/router.py
+++ b/app/admin/router.py
@@ -19,7 +19,7 @@ templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 
 # Keys that can be edited from the admin UI
 _EDITABLE_KEYS = [
-    "LLM_ENABLED", "LLM_BACKEND", "LLM_ENDPOINT", "LLM_MODEL",
+    "LLM_ENABLED", "LLM_BACKEND", "LLM_ENDPOINT", "LLM_OLLAMA_ENDPOINT", "LLM_MODEL",
     "TTS_ENABLED", "TTS_ENDPOINT",
     "CLASSIFIER_ENABLED", "CLASSIFIER_ENDPOINT",
     "REMOTE_SAVE_ENABLED", "REMOTE_SAVE_ENDPOINT",

--- a/app/admin/templates/dashboard.html
+++ b/app/admin/templates/dashboard.html
@@ -712,9 +712,13 @@ document.addEventListener('DOMContentLoaded', function() {
                 </label>
                 {% if descriptions.get('LLM_ENABLED') %}<small style="color:var(--pico-muted-color);">{{ descriptions['LLM_ENABLED'] }}</small>{% endif %}
                 </div>
-                <label for="LLM_ENDPOINT">Endpoint
+                <label for="LLM_ENDPOINT">Endpoint (llama-cpp)
                     <input type="text" id="LLM_ENDPOINT" name="LLM_ENDPOINT" value="{{ config['LLM_ENDPOINT'] }}">
                     {% if descriptions.get('LLM_ENDPOINT') %}<small>{{ descriptions['LLM_ENDPOINT'] }}</small>{% endif %}
+                </label>
+                <label for="LLM_OLLAMA_ENDPOINT">Endpoint (ollama)
+                    <input type="text" id="LLM_OLLAMA_ENDPOINT" name="LLM_OLLAMA_ENDPOINT" value="{{ config['LLM_OLLAMA_ENDPOINT'] }}">
+                    {% if descriptions.get('LLM_OLLAMA_ENDPOINT') %}<small>{{ descriptions['LLM_OLLAMA_ENDPOINT'] }}</small>{% endif %}
                 </label>
             </div>
             <div class="grid">
@@ -833,18 +837,25 @@ document.addEventListener('DOMContentLoaded', function() {
 </div>
 
 <script>
-// Toggle LLM_MODEL and LLM_KEEP_ALIVE fields based on LLM_BACKEND selection
+// Toggle LLM fields based on LLM_BACKEND selection:
+// - Show the correct endpoint field for the active backend
+// - Enable/disable Model and Keep Alive (ollama-only fields)
 (function() {
     var backendSel = document.getElementById('LLM_BACKEND');
     var modelInput = document.getElementById('LLM_MODEL');
     var keepAliveInput = document.getElementById('LLM_KEEP_ALIVE');
-    function toggleOllamaFields() {
+    var llamaEndpoint = document.getElementById('LLM_ENDPOINT').closest('label');
+    var ollamaEndpoint = document.getElementById('LLM_OLLAMA_ENDPOINT').closest('label');
+
+    function toggleBackendFields() {
         var isOllama = backendSel.value === 'ollama';
         modelInput.disabled = !isOllama;
         keepAliveInput.disabled = !isOllama;
+        llamaEndpoint.style.display = isOllama ? 'none' : '';
+        ollamaEndpoint.style.display = isOllama ? '' : 'none';
     }
-    backendSel.addEventListener('change', toggleOllamaFields);
-    toggleOllamaFields();
+    backendSel.addEventListener('change', toggleBackendFields);
+    toggleBackendFields();
 })();
 </script>
 {% endblock %}

--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,7 @@ _DEFAULTS: dict[str, Any] = {
     "LLM_ENABLED": True,
     "LLM_BACKEND": "llama-cpp",  # "llama-cpp" or "ollama" (Hailo AI HAT+)
     "LLM_ENDPOINT": "http://llm:8000",
+    "LLM_OLLAMA_ENDPOINT": "http://localhost:11434",  # Default endpoint for Ollama / hailo-ollama
     "LLM_MODEL": "qwen2:1.5b",  # Ollama model name (only used when LLM_BACKEND=ollama)
     "TTS_ENABLED": True,
     "TTS_ENDPOINT": "http://tts:5000",
@@ -99,7 +100,8 @@ _DESCRIPTIONS: dict[str, str] = {
     # LLM
     "LLM_ENABLED": "Enable the LLM service for generating text descriptions of brews",
     "LLM_BACKEND": "'llama-cpp' for the built-in GGUF server, 'ollama' for Hailo AI HAT+ / hailo-ollama",
-    "LLM_ENDPOINT": "URL of the LLM service",
+    "LLM_ENDPOINT": "URL of the LLM service (llama-cpp default: port 8000, ollama default: port 11434)",
+    "LLM_OLLAMA_ENDPOINT": "Default Ollama endpoint used when switching backend to ollama (standard port 11434)",
     "LLM_MODEL": "Ollama model name (only used when LLM_BACKEND=ollama)",
     "LLM_MAX_TOKENS": "Maximum number of tokens the LLM may generate per request",
     "LLM_TEMPERATURE": "Controls randomness: lower is more deterministic, higher is more creative (0.0\u20132.0)",

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -26,14 +26,21 @@ class LLMClient:
     """Calls LLM /generate and /health endpoints."""
 
     @staticmethod
+    def _endpoint() -> str:
+        """Return the active endpoint URL for the selected backend."""
+        if config.LLM_BACKEND == "ollama":
+            return config.LLM_OLLAMA_ENDPOINT
+        return config.LLM_ENDPOINT
+
+    @staticmethod
     async def health() -> dict[str, Any]:
         if config.LLM_BACKEND == "ollama":
-            return await ollama_health(config.LLM_ENDPOINT)
+            return await ollama_health(LLMClient._endpoint())
 
         # Default: llama-cpp custom server
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
-                r = await client.get(f"{config.LLM_ENDPOINT}/health")
+                r = await client.get(f"{LLMClient._endpoint()}/health")
                 r.raise_for_status()
                 return {"enabled": True, "healthy": True, **r.json()}
         except Exception as exc:
@@ -81,7 +88,7 @@ class LLMClient:
         # ── Ollama / Hailo backend ──────────────────────────────
         if config.LLM_BACKEND == "ollama":
             return await ollama_generate(
-                endpoint=config.LLM_ENDPOINT,
+                endpoint=LLMClient._endpoint(),
                 model=config.LLM_MODEL,
                 prompt=prompt,
                 max_tokens=max_tokens,
@@ -96,7 +103,7 @@ class LLMClient:
         try:
             async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
                 r = await client.post(
-                    f"{config.LLM_ENDPOINT}/generate",
+                    f"{LLMClient._endpoint()}/generate",
                     json={
                         "prompt": prompt,
                         "max_tokens": max_tokens,


### PR DESCRIPTION
## Summary

When switching LLM_BACKEND to **ollama** in the admin panel, the LLM health check was still hitting LLM_ENDPOINT (port 8000) where the llama-cpp Docker container runs. The llama-cpp server has no /api/tags route, so the ollama health check (GET /api/tags) always failed  causing the LLM status dot to show unhealthy in both admin and kiosk mode.

### Root Cause

Both backends shared a single LLM_ENDPOINT config key. When switching to ollama, the endpoint URL still pointed at the llama-cpp Docker container on port 8000, and the ollama health probe hit the wrong service.

### Fix

Introduce a dedicated **\LLM_OLLAMA_ENDPOINT\** config key (default \http://localhost:11434\, standard Ollama port) so each backend has its own persisted endpoint URL that cannot conflict.

### Changes

- **\pp/config.py\**  add \LLM_OLLAMA_ENDPOINT\ to defaults and descriptions
- **\pp/services/llm_client.py\**  add \LLMClient._endpoint()\ helper that returns the correct URL for the active backend; all health and generate calls use it
- **\pp/admin/router.py\**  add \LLM_OLLAMA_ENDPOINT\ to editable keys
- **\pp/admin/templates/dashboard.html\**  show two separate endpoint fields (llama-cpp / ollama) and toggle visibility based on the selected backend