### PR TITLE
fix: clean up old audio files before writing new TTS output

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -35,6 +35,18 @@ logger = logging.getLogger("rpicoffee.pipeline")
 AUDIO_DIR = Path(os.environ.get("DATA_DIR", str(Path(__file__).resolve().parent.parent / "data"))) / "audio"
 
 
+def _cleanup_audio() -> None:
+    """Remove old WAV files from the audio directory."""
+    try:
+        for wav in AUDIO_DIR.glob("*.wav"):
+            try:
+                wav.unlink()
+            except OSError:
+                logger.warning("Could not delete %s", wav)
+    except OSError:
+        logger.warning("Could not list audio directory for cleanup")
+
+
 async def run_pipeline(
     sensor_data: list[dict[str, float]] | None = None,
     on_progress: Any | None = None,
@@ -145,6 +157,7 @@ async def run_pipeline(
             if not result["error"]:
                 result["error"] = "Speech synthesis unavailable"
         else:
+            _cleanup_audio()
             audio_id = uuid.uuid4().hex[:12]
             audio_path = AUDIO_DIR / f"{audio_id}.wav"
             AUDIO_DIR.mkdir(parents=True, exist_ok=True)
@@ -269,6 +282,7 @@ async def run_pipeline_streaming() -> AsyncGenerator[str, None]:
             if not result["error"]:
                 result["error"] = "Speech synthesis unavailable"
         else:
+            _cleanup_audio()
             audio_id = uuid.uuid4().hex[:12]
             audio_path = AUDIO_DIR / f"{audio_id}.wav"
             AUDIO_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

TTS audio files (WAV) were written to data/audio/ with unique UUID names on every brew, but never cleaned up. Over time this causes unbounded disk growth  particularly problematic on the Raspberry Pi's limited storage.

### Changes

- Added _cleanup_audio() helper in pp/pipeline.py that globs *.wav from the audio directory and deletes them
- Called _cleanup_audio() before writing the new audio file in both un_pipeline() and un_pipeline_streaming()
- Errors during cleanup are logged as warnings but do not block the pipeline

### Files Changed
- pp/pipeline.py  added cleanup helper and two call sites