### PR TITLE
fix: use LLM_OLLAMA_ENDPOINT for ollama health checks in shell scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,5 @@ REMOTE_SAVE_PORT=7000
 
 # ─── Service endpoints (localhost for native-app mode) ────────
 CLASSIFIER_ENDPOINT=http://localhost:${CLASSIFIER_PORT}
-LLM_ENDPOINT=http://localhost:${LLM_PORT}
-TTS_ENDPOINT=http://localhost:${TTS_PORT}
+LLM_ENDPOINT=http://localhost:${LLM_PORT}LLM_OLLAMA_ENDPOINT=http://localhost:${OLLAMA_PORT}TTS_ENDPOINT=http://localhost:${TTS_PORT}
 REMOTE_SAVE_ENDPOINT=http://localhost:${REMOTE_SAVE_PORT}

--- a/setup.sh
+++ b/setup.sh
@@ -249,12 +249,14 @@ if [[ "$CONFIGURE_ENV" == "true" ]]; then
     env_set .env APP_PORT           "8080"
     env_set .env CLASSIFIER_PORT    "8001"
     env_set .env LLM_PORT           "8002"
+    env_set .env OLLAMA_PORT         "8000"
     env_set .env TTS_PORT           "5050"
     env_set .env REMOTE_SAVE_PORT   "7000"
 
     # Endpoints are always localhost in native mode — set automatically
     env_set .env CLASSIFIER_ENDPOINT "http://localhost:8001"
     env_set .env LLM_ENDPOINT        "http://localhost:8002"
+    env_set .env LLM_OLLAMA_ENDPOINT  "http://localhost:8000"
     env_set .env TTS_ENDPOINT        "http://localhost:5050"
     env_set .env REMOTE_SAVE_ENDPOINT "http://localhost:7000"
 

--- a/start.sh
+++ b/start.sh
@@ -87,7 +87,7 @@ fi
 
 # ── External service health checks (not Docker-managed) ─────────
 if [[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
-    LLM_URL="${LLM_ENDPOINT:-http://localhost:8002}"
+    LLM_URL="${LLM_OLLAMA_ENDPOINT:-http://localhost:8000}"
     echo -n "  Waiting for ollama (${LLM_URL}) "
     TRIES=0; MAX_TRIES=30
     while ! curl -sf --max-time 2 "${LLM_URL}/api/tags" > /dev/null 2>&1; do

--- a/status.sh
+++ b/status.sh
@@ -187,13 +187,15 @@ fi
 
 # --- LLM ---
 if [[ "${LLM_ENABLED:-false}" == "true" ]]; then
-    read -r l_host l_port <<< "$(parse_endpoint "${LLM_ENDPOINT:-http://localhost:8002}")"
     if [[ "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
-        # External service — check /api/tags instead of /health
+        # External service — use the dedicated Ollama endpoint
+        _OLLAMA_URL="${LLM_OLLAMA_ENDPOINT:-http://localhost:8000}"
+        read -r l_host l_port <<< "$(parse_endpoint "$_OLLAMA_URL")"
         STATUS[llm]="external (ollama)"
-        HEALTH[llm]="$(http_health "${LLM_ENDPOINT:-http://localhost:8002}/api/tags")"
+        HEALTH[llm]="$(http_health "${_OLLAMA_URL}/api/tags")"
         EXTRA[llm]="backend=ollama model=${LLM_MODEL:-qwen2:1.5b}"
     else
+        read -r l_host l_port <<< "$(parse_endpoint "${LLM_ENDPOINT:-http://localhost:8002}")"
         STATUS[llm]="$(container_status rpicoffee-llm)"
         HEALTH[llm]="$(http_health "${LLM_ENDPOINT:-http://localhost:8002}/health")"
         EXTRA[llm]="backend=llama-cpp"


### PR DESCRIPTION
After moving llama.cpp to port 8002 (PR #16), status.sh and start.sh were still using LLM_ENDPOINT (port 8002) for ollama health checks. When LLM_BACKEND=ollama, ollama runs on port 8000 via LLM_OLLAMA_ENDPOINT so the health checks hit the wrong port and always showed unreachable. Fixed status.sh, start.sh, .env.example, and setup.sh to use LLM_OLLAMA_ENDPOINT for ollama backend.