### PR TITLE
fix: systemd service fails to start - invalid port variable syntax

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -517,7 +517,7 @@ Type=simple
 WorkingDirectory=${SCRIPT_DIR}/app
 Environment="PATH=${VENV_DIR}/bin:/usr/local/bin:/usr/bin:/bin"
 EnvironmentFile=${SCRIPT_DIR}/.env
-ExecStart=${VENV_DIR}/bin/uvicorn main:app --host 0.0.0.0 --port \${APP_PORT:-8080}
+ExecStart=${VENV_DIR}/bin/uvicorn main:app --host 0.0.0.0 --port \${APP_PORT}
 Restart=on-failure
 RestartSec=5
 User=${USER}


### PR DESCRIPTION
The rpicoffee-app systemd unit used bash-style default syntax in ExecStart: --port . Systemd supports  expansion from EnvironmentFile but does NOT support  syntax, so the literal string was passed to uvicorn causing 'not a valid integer' error and a crash loop. Fix: remove the :-8080 default since APP_PORT is always set in .env by setup.sh.