### PR TITLE
ui: move Admin Settings link to topbar as gear icon

### DIFF
--- a/app/admin/templates/index.html
+++ b/app/admin/templates/index.html
@@ -31,7 +31,7 @@
         }
         .topbar .title { font-weight: 700; font-size: 1.2rem; }
         .topbar .clock { font-variant-numeric: tabular-nums; opacity: 0.85; }
-        .topbar .status-dots { display: flex; gap: 0.8rem; align-items: center; }
+        .topbar .status-dots { display: flex; gap: 0.8rem; align-items: center; flex: 1; justify-content: center; }
         .topbar .status-item { display: flex; align-items: center; gap: 0.3rem; font-size: 0.8rem; color: #ccc; }
         .topbar .right-group { margin-left: auto; display: flex; align-items: center; gap: 0.6rem; }
 


### PR DESCRIPTION
Moves the Admin Settings link from below the Brew button to the topbar as a gear icon () next to the clock.

**Changes:**
- Added  gear icon link in the topbar, right of the clock
- Removed the text 'Admin Settings' link from the left column
- Subtle styling: 60% white opacity, full white on hover

Keeps the kiosk layout cleaner with the admin link always visible in the top bar.