### PR TITLE
ui: fix kiosk brew-status overflow, clear results on capture, hide unavailable errors

### DIFF
--- a/app/admin/templates/index.html
+++ b/app/admin/templates/index.html
@@ -56,6 +56,7 @@
             display: flex; flex-direction: row;
             gap: 0.6rem;
             flex-shrink: 0;
+            height: 160px;
         }
         .left-col {
             display: flex; flex-direction: column;
@@ -103,8 +104,7 @@
             border: 1px solid var(--pico-muted-border-color);
             border-radius: 12px;
             padding: 0.8rem 1rem;
-            flex: 1;
-            min-height: 0;
+            height: 100%;
             overflow-y: auto;
         }
         .result-card .label-badge {


### PR DESCRIPTION
Fixes three kiosk UI issues:

**1. Brew status text overflows behind result panel**
- Added `word-wrap: break-word` and `overflow-wrap: break-word` to `.brew-status` so long status messages like "Vibration detected! Recording sensor data..." wrap within the 300px left column instead of clipping behind the result card

**2. Results not cleared on new auto-trigger capture**
- When a new recording starts via auto-trigger, the previous classification result, generated text, and audio are now cleared from the result panel
- The placeholder text is restored until new results arrive

**3. "Unavailable" error messages shown in result panel**
- Messages like "Text generation unavailable" are now filtered out before rendering
- Applies to both manual brew and auto-trigger flows
- Uses regex to strip any `error-note` paragraph containing "unavailable"
