### PR TITLE
feat: automatic hailo-ollama lifecycle management

### DIFF
--- a/app/admin/router.py
+++ b/app/admin/router.py
@@ -140,7 +140,8 @@ async def update_settings(request: Request, session: str | None = Cookie(default
     form = await request.form()
     updates: dict = {}
 
-    # Snapshot current sensor config for change detection
+    # Snapshot current config for change detection
+    old_backend = config.get("LLM_BACKEND")
     old_sensor = {k: config.get(k) for k in _SENSOR_KEYS}
 
     for key in _EDITABLE_KEYS:
@@ -152,6 +153,25 @@ async def update_settings(request: Request, session: str | None = Cookie(default
 
     config.update_many(updates)
     logger.info("Settings updated: %s", list(updates.keys()))
+
+    # If LLM backend changed, start/stop hailo-ollama service
+    new_backend = config.get("LLM_BACKEND")
+    if old_backend != new_backend:
+        from services.hailo_ollama_manager import start_and_enable, stop_and_disable
+        if new_backend == "ollama":
+            logger.info("LLM backend → ollama: starting hailo-ollama service")
+            try:
+                healthy = await start_and_enable()
+                if not healthy:
+                    logger.warning("hailo-ollama started but health check did not pass")
+            except Exception:
+                logger.exception("Failed to start hailo-ollama service")
+        else:
+            logger.info("LLM backend → %s: stopping hailo-ollama service", new_backend)
+            try:
+                await stop_and_disable()
+            except Exception:
+                logger.exception("Failed to stop hailo-ollama service")
 
     # If any sensor-related setting changed, restart the sensor
     new_sensor = {k: config.get(k) for k in _SENSOR_KEYS}

--- a/app/services/hailo_ollama_manager.py
+++ b/app/services/hailo_ollama_manager.py
@@ -1,0 +1,88 @@
+"""Manage the rpicoffee-hailo-ollama systemd service.
+
+Since the app runs natively on the host (not in Docker), we can call
+``systemctl`` directly.  A sudoers drop-in installed by ``setup.sh``
+grants the app user passwordless access to the four commands below.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+
+from config import config
+
+logger = logging.getLogger("rpicoffee.hailo_ollama")
+
+_UNIT = "rpicoffee-hailo-ollama"
+
+
+# ── Low-level helpers ────────────────────────────────────────────
+
+async def _systemctl(*args: str) -> tuple[int, str]:
+    """Run a ``systemctl`` sub-command and return (returncode, stdout)."""
+    cmd = ["sudo", "systemctl", *args, _UNIT]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await proc.communicate()
+    text = stdout.decode().strip() if stdout else ""
+    logger.debug("systemctl %s → rc=%s  %s", " ".join(args), proc.returncode, text)
+    return proc.returncode, text
+
+
+# ── Public API ───────────────────────────────────────────────────
+
+async def is_active() -> bool:
+    """Return *True* if the hailo-ollama service is currently running."""
+    rc, _ = await _systemctl("is-active")
+    return rc == 0
+
+
+async def is_enabled() -> bool:
+    """Return *True* if the hailo-ollama service is enabled at boot."""
+    rc, _ = await _systemctl("is-enabled")
+    return rc == 0
+
+
+async def start_and_enable(timeout: int = 60) -> bool:
+    """Start the service, enable it at boot, and wait for the health endpoint.
+
+    Returns *True* if the service is healthy within *timeout* seconds.
+    """
+    logger.info("Starting and enabling %s …", _UNIT)
+
+    await _systemctl("enable")
+    await _systemctl("start")
+
+    # Poll the health endpoint until it responds or we run out of time
+    endpoint = config.get("LLM_OLLAMA_ENDPOINT") or "http://localhost:8000"
+    health_url = f"{endpoint}/api/tags"
+    elapsed = 0
+    interval = 2
+    while elapsed < timeout:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(health_url, timeout=2)
+                if resp.status_code == 200:
+                    logger.info("%s is healthy (%s)", _UNIT, health_url)
+                    return True
+        except Exception:
+            pass
+        await asyncio.sleep(interval)
+        elapsed += interval
+
+    logger.error("%s did not become healthy within %ss", _UNIT, timeout)
+    return False
+
+
+async def stop_and_disable() -> None:
+    """Stop the running service and disable it from starting at boot."""
+    logger.info("Stopping and disabling %s …", _UNIT)
+    await _systemctl("stop")
+    await _systemctl("disable")
+    logger.info("%s stopped and disabled", _UNIT)

--- a/setup.sh
+++ b/setup.sh
@@ -191,6 +191,29 @@ if $GROUP_CHANGED; then
     warn "Group membership changed – log out & back in (or reboot) for it to take effect"
 fi
 
+# hailo-ollama (installed later in Phase 7, but we detect it early)
+if command -v hailo-ollama &>/dev/null; then
+    ok "hailo-ollama binary found: $(command -v hailo-ollama)"
+    HAILO_OLLAMA_INSTALLED=true
+else
+    HAILO_OLLAMA_INSTALLED=false
+    # Check if the .deb is available in the project root
+    HAILO_DEB=$(ls "${SCRIPT_DIR}"/hailo_gen_ai_model_zoo_*.deb 2>/dev/null | head -1 || true)
+    if [[ -n "$HAILO_DEB" ]]; then
+        info "Found hailo package: $(basename "$HAILO_DEB")"
+        info "Installing hailo_gen_ai_model_zoo..."
+        if sudo apt install -y "$HAILO_DEB" >> "$LOG_FILE" 2>&1; then
+            ok "hailo_gen_ai_model_zoo installed"
+            HAILO_OLLAMA_INSTALLED=true
+        else
+            fail "hailo_gen_ai_model_zoo install failed — check $LOG_FILE"
+        fi
+    else
+        info "hailo-ollama not installed (needed only if LLM backend = ollama)"
+        info "Download the .deb from https://hailo.ai/developer-zone/ and place it in ${SCRIPT_DIR}/"
+    fi
+fi
+
 # ════════════════════════════════════════════════════════════════
 #  Phase 2: Environment Configuration
 # ════════════════════════════════════════════════════════════════
@@ -373,6 +396,44 @@ if [[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" != "ollam
     fi
 elif [[ "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
     info "LLM using hailo-ollama — GGUF model not needed"
+    # Pull the configured model into hailo-ollama
+    if [[ "${HAILO_OLLAMA_INSTALLED:-false}" == "true" ]]; then
+        _OLLAMA_MODEL="${LLM_MODEL:-qwen2:1.5b}"
+        info "Pulling model '${_OLLAMA_MODEL}' into hailo-ollama..."
+        # Start hailo-ollama temporarily in the background
+        hailo-ollama &
+        _HAILO_PID=$!
+        _PULL_URL="http://localhost:8000"
+        _PULL_TRIES=0; _PULL_MAX=30
+        echo -n "  Waiting for hailo-ollama to start "
+        while ! curl -sf --max-time 2 "${_PULL_URL}/api/tags" > /dev/null 2>&1; do
+            ((_PULL_TRIES++))
+            if (( _PULL_TRIES >= _PULL_MAX )); then
+                echo ""
+                fail "hailo-ollama did not start within ${_PULL_MAX}×2s"
+                break
+            fi
+            echo -n "."
+            sleep 2
+        done
+        if (( _PULL_TRIES < _PULL_MAX )); then
+            echo ""
+            if curl -sf --max-time 300 "${_PULL_URL}/api/pull" \
+                 -H 'Content-Type: application/json' \
+                 -d "{\"model\": \"${_OLLAMA_MODEL}\", \"stream\": true}" \
+                 >> "$LOG_FILE" 2>&1; then
+                ok "Model '${_OLLAMA_MODEL}' pulled successfully"
+            else
+                fail "Model pull failed — check $LOG_FILE"
+            fi
+        fi
+        # Stop the temporary hailo-ollama process
+        kill "$_HAILO_PID" 2>/dev/null || true
+        wait "$_HAILO_PID" 2>/dev/null || true
+    else
+        warn "hailo-ollama not installed — cannot pull model; install later and run:"
+        warn "  hailo-ollama &  then  curl http://localhost:8000/api/pull -H 'Content-Type: application/json' -d '{\"model\": \"${LLM_MODEL:-qwen2:1.5b}\"}'"
+    fi
 else
     info "LLM disabled — skipping model download"
 fi
@@ -514,12 +575,57 @@ TimeoutStartSec=0
 WantedBy=multi-user.target
 EOF
 
+    # hailo-ollama unit (only when using ollama backend)
+    if [[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
+        HAILO_BIN="$(command -v hailo-ollama 2>/dev/null || echo /usr/bin/hailo-ollama)"
+        sudo tee /etc/systemd/system/rpicoffee-hailo-ollama.service > /dev/null <<EOF
+[Unit]
+Description=rpiCoffee hailo-ollama LLM Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${HAILO_BIN}
+Restart=on-failure
+RestartSec=5
+User=${USER}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+        ok "hailo-ollama systemd service created"
+        HAILO_UNIT_CREATED=true
+    else
+        # Ensure stale unit is disabled if switching away from ollama
+        if systemctl is-enabled rpicoffee-hailo-ollama &>/dev/null 2>&1; then
+            sudo systemctl stop rpicoffee-hailo-ollama 2>/dev/null || true
+            sudo systemctl disable rpicoffee-hailo-ollama 2>/dev/null || true
+            info "Disabled stale rpicoffee-hailo-ollama service"
+        fi
+        HAILO_UNIT_CREATED=false
+    fi
+
+    # Sudoers drop-in for hailo-ollama management from the app
+    sudo tee /etc/sudoers.d/rpicoffee-hailo-ollama > /dev/null <<EOF
+${USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl start rpicoffee-hailo-ollama, /usr/bin/systemctl stop rpicoffee-hailo-ollama, /usr/bin/systemctl enable rpicoffee-hailo-ollama, /usr/bin/systemctl disable rpicoffee-hailo-ollama, /usr/bin/systemctl is-active rpicoffee-hailo-ollama, /usr/bin/systemctl is-enabled rpicoffee-hailo-ollama
+EOF
+    sudo chmod 0440 /etc/sudoers.d/rpicoffee-hailo-ollama
+    ok "Sudoers drop-in for hailo-ollama management created"
+
     # App unit
+    HAILO_AFTER=""
+    HAILO_WANTS=""
+    if [[ "${HAILO_UNIT_CREATED:-false}" == "true" ]]; then
+        HAILO_AFTER=" rpicoffee-hailo-ollama.service"
+        HAILO_WANTS="Wants=rpicoffee-hailo-ollama.service"
+    fi
     sudo tee /etc/systemd/system/rpicoffee-app.service > /dev/null <<EOF
 [Unit]
 Description=rpiCoffee Application
-After=rpicoffee-services.service
+After=rpicoffee-services.service${HAILO_AFTER}
 Requires=rpicoffee-services.service
+${HAILO_WANTS}
 
 [Service]
 Type=simple
@@ -636,8 +742,13 @@ EOF
     ok "Kiosk systemd service created"
 
     sudo systemctl daemon-reload
-    sudo systemctl enable rpicoffee-services rpicoffee-app rpicoffee-kiosk
-    ok "Systemd services created and enabled (including kiosk)"
+    ENABLE_UNITS="rpicoffee-services rpicoffee-app rpicoffee-kiosk"
+    if [[ "${HAILO_UNIT_CREATED:-false}" == "true" ]]; then
+        ENABLE_UNITS="rpicoffee-hailo-ollama $ENABLE_UNITS"
+    fi
+    # shellcheck disable=SC2086
+    sudo systemctl enable $ENABLE_UNITS
+    ok "Systemd services created and enabled"
 else
     info "Skipping systemd setup"
 fi
@@ -717,6 +828,18 @@ if [[ "${SENSOR_MODE:-mock}" == "picoquake" ]]; then
     fi
 else
     info "USB sensor: not configured (mode=${SENSOR_MODE:-mock})"
+fi
+
+# hailo-ollama
+if [[ "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
+    if [[ "${HAILO_OLLAMA_INSTALLED:-false}" == "true" ]]; then
+        ok "hailo-ollama: installed"
+    else
+        warn "hailo-ollama: NOT installed — download from https://hailo.ai/developer-zone/"
+    fi
+    if [[ "${HAILO_UNIT_CREATED:-false}" == "true" ]]; then
+        ok "hailo-ollama: systemd service enabled (auto-start at boot)"
+    fi
 fi
 
 # Systemd

--- a/start.sh
+++ b/start.sh
@@ -87,6 +87,14 @@ fi
 
 # ── External service health checks (not Docker-managed) ─────────
 if [[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
+    # Ensure hailo-ollama service is started
+    if systemctl is-active rpicoffee-hailo-ollama &>/dev/null 2>&1; then
+        ok "hailo-ollama service already running"
+    else
+        info "Starting hailo-ollama service..."
+        sudo systemctl start rpicoffee-hailo-ollama 2>/dev/null || true
+    fi
+
     LLM_URL="${LLM_OLLAMA_ENDPOINT:-http://localhost:8000}"
     echo -n "  Waiting for ollama (${LLM_URL}) "
     TRIES=0; MAX_TRIES=30

--- a/status.sh
+++ b/status.sh
@@ -191,7 +191,10 @@ if [[ "${LLM_ENABLED:-false}" == "true" ]]; then
         # External service — use the dedicated Ollama endpoint
         _OLLAMA_URL="${LLM_OLLAMA_ENDPOINT:-http://localhost:8000}"
         read -r l_host l_port <<< "$(parse_endpoint "$_OLLAMA_URL")"
-        STATUS[llm]="external (ollama)"
+        # Show systemd unit status alongside health
+        _HAILO_ACTIVE="$(systemctl is-active rpicoffee-hailo-ollama 2>/dev/null || echo unknown)"
+        _HAILO_ENABLED="$(systemctl is-enabled rpicoffee-hailo-ollama 2>/dev/null || echo unknown)"
+        STATUS[llm]="external (ollama) unit=${_HAILO_ACTIVE}/${_HAILO_ENABLED}"
         HEALTH[llm]="$(http_health "${_OLLAMA_URL}/api/tags")"
         EXTRA[llm]="backend=ollama model=${LLM_MODEL:-qwen2:1.5b}"
     else

--- a/stop.sh
+++ b/stop.sh
@@ -21,10 +21,21 @@ else
     info "Application was not running"
 fi
 
-# ── Stop Docker services ─────────────────────────────────────────
+# ── Stop hailo-ollama if running ─────────────────────────────────
 if [[ -f .env ]]; then
     set -a; source .env; set +a
 fi
+
+if [[ "${LLM_ENABLED:-false}" == "true" && "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
+    if systemctl is-active rpicoffee-hailo-ollama &>/dev/null 2>&1; then
+        sudo systemctl stop rpicoffee-hailo-ollama 2>/dev/null || true
+        ok "hailo-ollama service stopped"
+    else
+        info "hailo-ollama service was not running"
+    fi
+fi
+
+# ── Stop Docker services ─────────────────────────────────────────
 
 PROFILES=""
 [[ "${CLASSIFIER_ENABLED:-false}"  == "true" ]] && PROFILES="$PROFILES --profile classifier"


### PR DESCRIPTION
Automatic lifecycle management for hailo-ollama based on LLM backend selection. When ollama is selected, the service is started and enabled at boot. When switching to llama-cpp, the service is stopped and disabled. Changes span setup.sh, admin router, start/stop/status scripts, and a new hailo_ollama_manager.py module.