### PR TITLE
fix: arithmetic increment exits under set -e when counter is 0

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -409,7 +409,7 @@ elif [[ "${LLM_BACKEND:-llama-cpp}" == "ollama" ]]; then
         _PULL_TRIES=0; _PULL_MAX=30
         echo -n "  Waiting for hailo-ollama to start "
         while ! curl -sf --max-time 2 "${_PULL_URL}/api/tags" > /dev/null 2>&1; do
-            ((_PULL_TRIES++))
+            _PULL_TRIES=$((_PULL_TRIES + 1))
             if (( _PULL_TRIES >= _PULL_MAX )); then
                 echo ""
                 fail "hailo-ollama did not start within ${_PULL_MAX}×2s"


### PR DESCRIPTION
((_PULL_TRIES++)) post-increment returns the OLD value (0) which bash treats as exit code 1, aborting the script on the first loop iteration. Use assignment form instead: _PULL_TRIES="