### PR TITLE
feat: allow autoplay in kiosk Chromium for TTS audio

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -714,6 +714,7 @@ fi
 export DISPLAY=:0
 exec $CHROMIUM_BIN \
   --kiosk "$APP_URL" \
+  --autoplay-policy=no-user-gesture-required \
   --password-store=basic \
   --disable-infobars \
   --noerrdialogs \


### PR DESCRIPTION
Add `--autoplay-policy=no-user-gesture-required` to the Chromium kiosk launch flags in setup.sh so that TTS audio can play without requiring a user gesture first.

## Changes
- **setup.sh**: Added `--autoplay-policy=no-user-gesture-required` flag to the Chromium `exec` block inside the generated `kiosk.sh` script

> **Note**: Existing deployments need to either re-run Phase 7 of setup.sh or manually add the flag to `~/rpiCoffee/kiosk.sh`.