### PR TITLE
fix: rename Test button to Simulate on kiosk page

### DIFF
--- a/app/admin/templates/index.html
+++ b/app/admin/templates/index.html
@@ -205,7 +205,7 @@
 
     <div class="left-col">
       <div class="brew-section">
-          <button class="brew-btn" id="brew-btn" onclick="brew()">&#9749; Test</button>
+          <button class="brew-btn" id="brew-btn" onclick="brew()">&#9749; Simulate</button>
       </div>
     </div>
 


### PR DESCRIPTION
Change the label of the brew button on the kiosk index page from **Test** to **Simulate**.