### PR TITLE
fix: correct training data path and improve training error messages

### DIFF
--- a/app/admin/templates/dashboard.html
+++ b/app/admin/templates/dashboard.html
@@ -958,6 +958,27 @@ async function trainModel() {
     btn.disabled = true;
     progress.style.display = '';
     results.style.display = 'none';
+    progressText.textContent = 'Checking training data…';
+
+    // Pre-flight: check that at least 2 coffee types have training data
+    try {
+        var tdResp = await fetch('/api/training-data');
+        var tdData = await tdResp.json();
+        var labels = Object.keys(tdData).filter(function(k) { return tdData[k].length > 0; });
+        if (labels.length < 2) {
+            progressText.removeAttribute('aria-busy');
+            btn.removeAttribute('aria-busy');
+            btn.disabled = false;
+            var msg = labels.length === 0
+                ? 'No training data found. Record sensor data for at least 2 different coffee types before training.'
+                : 'Only 1 coffee type found (<strong>' + labels[0] + '</strong>). Record training data for at least one more coffee type before training a classifier.';
+            results.innerHTML = '<p style="color:var(--pico-del-color);">' + msg + '</p>';
+            results.style.display = '';
+            progress.style.display = 'none';
+            return;
+        }
+    } catch(e) { /* proceed anyway — the classifier will catch it */ }
+
     progressText.textContent = 'Starting training…';
 
     try {

--- a/app/services/training_data.py
+++ b/app/services/training_data.py
@@ -20,7 +20,7 @@ from typing import Any
 
 logger = logging.getLogger("rpicoffee.training_data")
 
-DATA_DIR = Path(os.environ.get("DATA_DIR", str(Path(__file__).resolve().parent.parent / "data")))
+DATA_DIR = Path(os.environ.get("DATA_DIR", str(Path(__file__).resolve().parent.parent.parent / "data")))
 TRAINING_DIR = DATA_DIR / "training"
 
 # CSV column header for training files (matches the existing .csv.sample format)

--- a/services/classifier/model_manager.py
+++ b/services/classifier/model_manager.py
@@ -182,9 +182,11 @@ class ModelManager:
 
             if not all_features:
                 self.training_status.is_training = False
-                self.training_status.error = "No training data found"
+                msg = f"No training data found in {data_path}"
+                self.training_status.error = msg
                 self.training_status.progress = "Failed"
-                return {"error": "No training data found", "status": "failed"}
+                logger.error(msg)
+                return {"error": msg, "status": "failed"}
 
             # Count samples per class
             from collections import Counter
@@ -194,10 +196,10 @@ class ModelManager:
             self.training_status.progress = f"Found {len(all_labels)} samples across {len(class_counts)} classes"
             logger.info("Training data: %s", dict(class_counts))
 
-            # Need at least 2 classes
+            # Need at least 2 classes for a meaningful classifier
             if len(class_counts) < 2:
                 self.training_status.is_training = False
-                self.training_status.error = f"Need at least 2 classes, found {len(class_counts)}: {list(class_counts.keys())}"
+                self.training_status.error = f"Need at least 2 coffee types to train a classifier. Found {len(class_counts)}: {list(class_counts.keys())}. Record training data for another coffee type and try again."
                 self.training_status.progress = "Failed"
                 return {"error": self.training_status.error, "status": "failed"}
 

--- a/setup.sh
+++ b/setup.sh
@@ -278,6 +278,9 @@ if [[ "$CONFIGURE_ENV" == "true" ]]; then
     prompt_yn "Enable remote-save service?" REMOTE_SAVE_ENABLED "y"
     env_set .env REMOTE_SAVE_ENABLED "$REMOTE_SAVE_ENABLED"
 
+    # Data directory (shared between app and Docker containers via volume mount)
+    env_set .env DATA_DIR           "${SCRIPT_DIR}/data"
+
     # Service ports (single source of truth for docker-compose.yml, scripts, etc.)
     env_set .env APP_PORT           "8080"
     env_set .env CLASSIFIER_PORT    "8001"


### PR DESCRIPTION
## Problem
Clicking **Train Model** in the admin UI fails with: Training failed: no training data found

## Root cause
`app/services/training_data.py` computed `DATA_DIR` with only two `.parent` calls, resolving to `app/data` instead of the project-root `data/` directory. Training CSVs were saved to the wrong location while the classifier Docker container reads from `data/training/` via volume mount.

## Changes
- **app/services/training_data.py**: Fix default DATA_DIR - add missing .parent so fallback resolves to project-root/data
- **setup.sh**: Add DATA_DIR to .env generation so the path is always explicit
- **services/classifier/model_manager.py**: Include scanned path in error message for debugging; improve 2-class requirement message with actionable guidance
- **app/admin/templates/dashboard.html**: Add pre-flight check before training - warn if fewer than 2 coffee types have training data

## Follow-up
On the RPi, move any previously saved recordings from the wrong path: `mv app/data/training/* data/training/`