### PR TITLE
fix: ensure training/models directories exist on host before container start

### DIFF
--- a/services/classifier/Dockerfile
+++ b/services/classifier/Dockerfile
@@ -7,8 +7,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-# Create directories for models and training data
-RUN mkdir -p /data/models /data/training
+# Note: /data is volume-mounted from the host at runtime (see docker-compose.yml).
+# The app creates /data/models and /data/training on startup if missing.
 
 EXPOSE 8001
 

--- a/services/classifier/main.py
+++ b/services/classifier/main.py
@@ -41,6 +41,13 @@ app = FastAPI(title="rpicoffee-classifier", version="2.0.0")
 _executor = ThreadPoolExecutor(max_workers=1)
 
 
+@app.on_event("startup")
+async def _ensure_dirs():
+    """Create data directories if they don't exist (covers volume-mount edge cases)."""
+    TRAINING_DIR.mkdir(parents=True, exist_ok=True)
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+
 # ── Request / Response models ────────────────────────────────────
 
 class SensorReading(BaseModel):

--- a/setup.sh
+++ b/setup.sh
@@ -468,6 +468,10 @@ fi
 # ════════════════════════════════════════════════════════════════
 header "Phase 5 · Docker image builds"
 
+# Ensure host data directories exist (volume-mounted into containers)
+mkdir -p "$SCRIPT_DIR/data/training" "$SCRIPT_DIR/data/models" "$SCRIPT_DIR/data/audio"
+ok "Data directories created"
+
 build_service() {
     local name="$1" profile="$2"
     info "Building $name..."

--- a/start.sh
+++ b/start.sh
@@ -49,6 +49,9 @@ echo ""
 echo -e "${BOLD}Starting rpiCoffee...${NC}"
 echo ""
 
+# Ensure host data directories exist (volume-mounted into containers)
+mkdir -p "$SCRIPT_DIR/data/training" "$SCRIPT_DIR/data/models" "$SCRIPT_DIR/data/audio"
+
 if [[ -n "$PROFILES" ]]; then
     info "Starting Docker services..."
     # shellcheck disable=SC2086


### PR DESCRIPTION
## Problem
`docker exec rpicoffee-classifier ls -R /data/training/` returns 'No such file or directory' on the RPi.

## Root cause
The Dockerfile creates `/data/models` and `/data/training` at **build time** with `RUN mkdir -p`, but the volume mount `./data:/data` in docker-compose.yml **overlays** `/data` entirely at runtime. If the host's `data/` directory doesn't contain `training/` or `models/` subdirectories, they won't exist inside the container.

Neither `setup.sh` nor `start.sh` created these directories on the host.

## Changes
- **setup.sh**: Create `data/training`, `data/models`, `data/audio` before Docker image builds
- **start.sh**: Create the same directories before `docker compose up`  
- **services/classifier/main.py**: Add FastAPI startup event that ensures the directories exist (safety net if the container is started outside of setup/start scripts)
- **services/classifier/Dockerfile**: Remove the now-redundant `RUN mkdir` and add a comment explaining the volume mount