### PR TITLE
fix: use app/data for training data and mount into classifier container

### DIFF
--- a/app/admin/templates/dashboard.html
+++ b/app/admin/templates/dashboard.html
@@ -958,6 +958,27 @@ async function trainModel() {
     btn.disabled = true;
     progress.style.display = '';
     results.style.display = 'none';
+    progressText.textContent = 'Checking training data…';
+
+    // Pre-flight: check that at least 2 coffee types have training data
+    try {
+        var tdResp = await fetch('/api/training-data');
+        var tdData = await tdResp.json();
+        var labels = Object.keys(tdData).filter(function(k) { return tdData[k].length > 0; });
+        if (labels.length < 2) {
+            progressText.removeAttribute('aria-busy');
+            btn.removeAttribute('aria-busy');
+            btn.disabled = false;
+            var msg = labels.length === 0
+                ? 'No training data found. Record sensor data for at least 2 different coffee types before training.'
+                : 'Only 1 coffee type found (<strong>' + labels[0] + '</strong>). Record training data for at least one more coffee type before training a classifier.';
+            results.innerHTML = '<p style="color:var(--pico-del-color);">' + msg + '</p>';
+            results.style.display = '';
+            progress.style.display = 'none';
+            return;
+        }
+    } catch(e) { /* proceed anyway — the classifier will catch it */ }
+
     progressText.textContent = 'Starting training…';
 
     try {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "${CLASSIFIER_PORT:-8001}:${CLASSIFIER_PORT:-8001}"
     volumes:
-      - ./data:/data
+      - ./app/data:/data
     environment:
       - MODEL_DIR=/data/models
       - TRAINING_DIR=/data/training

--- a/services/classifier/Dockerfile
+++ b/services/classifier/Dockerfile
@@ -7,8 +7,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-# Create directories for models and training data
-RUN mkdir -p /data/models /data/training
+# Note: /data is volume-mounted from the host at runtime (see docker-compose.yml).
+# The app creates /data/models and /data/training on startup if missing.
 
 EXPOSE 8001
 

--- a/services/classifier/main.py
+++ b/services/classifier/main.py
@@ -41,6 +41,13 @@ app = FastAPI(title="rpicoffee-classifier", version="2.0.0")
 _executor = ThreadPoolExecutor(max_workers=1)
 
 
+@app.on_event("startup")
+async def _ensure_dirs():
+    """Create data directories if they don't exist (covers volume-mount edge cases)."""
+    TRAINING_DIR.mkdir(parents=True, exist_ok=True)
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+
 # ── Request / Response models ────────────────────────────────────
 
 class SensorReading(BaseModel):

--- a/services/classifier/model_manager.py
+++ b/services/classifier/model_manager.py
@@ -182,9 +182,11 @@ class ModelManager:
 
             if not all_features:
                 self.training_status.is_training = False
-                self.training_status.error = "No training data found"
+                msg = f"No training data found in {data_path}"
+                self.training_status.error = msg
                 self.training_status.progress = "Failed"
-                return {"error": "No training data found", "status": "failed"}
+                logger.error(msg)
+                return {"error": msg, "status": "failed"}
 
             # Count samples per class
             from collections import Counter
@@ -194,10 +196,10 @@ class ModelManager:
             self.training_status.progress = f"Found {len(all_labels)} samples across {len(class_counts)} classes"
             logger.info("Training data: %s", dict(class_counts))
 
-            # Need at least 2 classes
+            # Need at least 2 classes for a meaningful classifier
             if len(class_counts) < 2:
                 self.training_status.is_training = False
-                self.training_status.error = f"Need at least 2 classes, found {len(class_counts)}: {list(class_counts.keys())}"
+                self.training_status.error = f"Need at least 2 coffee types to train a classifier. Found {len(class_counts)}: {list(class_counts.keys())}. Record training data for another coffee type and try again."
                 self.training_status.progress = "Failed"
                 return {"error": self.training_status.error, "status": "failed"}
 

--- a/setup.sh
+++ b/setup.sh
@@ -468,6 +468,10 @@ fi
 # ════════════════════════════════════════════════════════════════
 header "Phase 5 · Docker image builds"
 
+# Ensure host data directories exist (app/data is volume-mounted into containers)
+mkdir -p "$SCRIPT_DIR/app/data/training" "$SCRIPT_DIR/app/data/models" "$SCRIPT_DIR/app/data/audio"
+ok "Data directories created"
+
 build_service() {
     local name="$1" profile="$2"
     info "Building $name..."

--- a/start.sh
+++ b/start.sh
@@ -49,6 +49,9 @@ echo ""
 echo -e "${BOLD}Starting rpiCoffee...${NC}"
 echo ""
 
+# Ensure host data directories exist (app/data is volume-mounted into containers)
+mkdir -p "$SCRIPT_DIR/app/data/training" "$SCRIPT_DIR/app/data/models" "$SCRIPT_DIR/app/data/audio"
+
 if [[ -n "$PROFILES" ]]; then
     info "Starting Docker services..."
     # shellcheck disable=SC2086


### PR DESCRIPTION
Supersedes #42 and #43.

## Problem
Training data CSVs are saved by the native app to `app/data/training/<label>/` but the classifier Docker container had `./data:/data` as its volume mount, so it could never see the training files. Running `docker exec rpicoffee-classifier ls /data/training/` returned 'No such file or directory'.

## Root cause
The app runs natively from the `app/` directory. `training_data.py` correctly defaults to `app/data/` as its data directory. But `docker-compose.yml` mounted `./data` (the project-root data dir) instead of `./app/data` into the container.
Also, the Dockerfile's `RUN mkdir -p /data/training` ran at build time but the volume mount overlays `/data` at runtime, hiding those directories.

## Changes
- **docker-compose.yml**: Volume mount changed from `./data:/data` to `./app/data:/data`  
- **setup.sh**: Create `app/data/{training,models,audio}` on host before Docker builds
- **start.sh**: Same mkdir before `docker compose up`  
- **services/classifier/Dockerfile**: Remove build-time mkdir (volume overlays it); add explanatory comment
- **services/classifier/main.py**: FastAPI startup event ensures dirs exist as safety net
- **services/classifier/model_manager.py**: Error messages now include the scanned path; 2-class requirement message gives actionable guidance
- **app/admin/templates/dashboard.html**: Pre-flight check fetches training data listing and warns if fewer than 2 coffee types exist before sending train request