### PR TITLE
fix: unwrap training_data response in dashboard pre-flight check

### DIFF
--- a/app/admin/templates/dashboard.html
+++ b/app/admin/templates/dashboard.html
@@ -963,7 +963,7 @@ async function trainModel() {
     // Pre-flight: check that at least 2 coffee types have training data
     try {
         var tdResp = await fetch('/api/training-data');
-        var tdData = await tdResp.json();
+        var tdData = (await tdResp.json()).training_data || {};
         var labels = Object.keys(tdData).filter(function(k) { return tdData[k].length > 0; });
         if (labels.length < 2) {
             progressText.removeAttribute('aria-busy');


### PR DESCRIPTION
## Problem
Clicking Train Model always shows 'No training data found' even with 15 training files across 3 coffee types.

## Root cause
The `/api/training-data` endpoint returns `{training_data: {black: [...], cappuccino: [...], espresso: [...]}}`, but the pre-flight JS did `Object.keys(tdData)` on the outer wrapper. This yielded `['training_data']` (length 1, no matching files array), so the check always concluded there were 0 labels.

## Fix
Unwrap the response: `(await tdResp.json()).training_data || {}`