### PR TITLE
feat: add classifier model download from admin panel

### DIFF
--- a/app/admin/router.py
+++ b/app/admin/router.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from pathlib import Path
 
 from fastapi import APIRouter, Cookie, Form, Request, Response
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from itsdangerous import BadSignature, URLSafeSerializer
 
 from config import _DESCRIPTIONS, config
 
 logger = logging.getLogger("rpicoffee.admin")
+
+_DATA_DIR = Path(os.environ.get("DATA_DIR", str(Path(__file__).resolve().parent.parent.parent / "data")))
+_MODEL_DIR = _DATA_DIR / "models"
 
 router = APIRouter()
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
@@ -195,6 +199,30 @@ def _redirect_with_fresh_session(url: str) -> RedirectResponse:
     response.set_cookie(key="session", value=_make_session_token(),
                         httponly=True, samesite="lax", max_age=600)
     return response
+
+
+# ── Model download ───────────────────────────────────────────
+
+@router.get("/download-model")
+async def download_model(session: str | None = Cookie(default=None)):
+    """Download the currently active classifier model (.joblib)."""
+    if not _verify_session(session):
+        return RedirectResponse(url="/admin/login", status_code=303)
+
+    if not _MODEL_DIR.is_dir():
+        return _redirect_with_fresh_session("/admin/?message=No+models+directory+found")
+
+    model_files = sorted(_MODEL_DIR.glob("coffee_classifier_*.joblib"))
+    if not model_files:
+        return _redirect_with_fresh_session("/admin/?message=No+trained+model+found")
+
+    latest = model_files[-1]
+    logger.info("Serving model download: %s", latest.name)
+    return FileResponse(
+        path=str(latest),
+        filename=latest.name,
+        media_type="application/octet-stream",
+    )
 
 
 # ── Sensor config (JSON API) ────────────────────────────────────

--- a/app/admin/templates/dashboard.html
+++ b/app/admin/templates/dashboard.html
@@ -904,6 +904,9 @@ document.addEventListener('DOMContentLoaded', refreshTrainingData);
             <small style="display:block;margin-top:0.3rem;color:var(--pico-muted-color);">Train on collected training data</small>
         </div>
         <div>
+            <a id="download-model-btn" href="/admin/download-model" role="button" class="outline" style="margin-bottom:0;display:none;">&#11123; Download Model</a>
+        </div>
+        <div>
             <label for="model-upload" style="margin-bottom:0;">Upload Model (.joblib)
                 <input type="file" id="model-upload" accept=".joblib" onchange="uploadModel()">
             </label>
@@ -932,6 +935,8 @@ async function loadModelInfo() {
         }
         if (!data.loaded) {
             el.innerHTML = '<p style="color:var(--pico-muted-color);">No model loaded. Train a model or upload one to get started.</p>';
+            var dlBtn = document.getElementById('download-model-btn');
+            if (dlBtn) dlBtn.style.display = 'none';
             return;
         }
         var html = '<div style="font-size:0.9rem;">';
@@ -941,6 +946,8 @@ async function loadModelInfo() {
         html += '<strong>Trained:</strong> ' + (data.trained_at || 'unknown');
         html += '</div>';
         el.innerHTML = html;
+        var dlBtn = document.getElementById('download-model-btn');
+        if (dlBtn) dlBtn.style.display = '';
     } catch(e) {
         el.innerHTML = '<p style="color:var(--pico-del-color);">Failed to load model info.</p>';
     }


### PR DESCRIPTION
## Summary

Adds the ability to download the trained classifier model (.joblib) directly from the admin panel dashboard.

## Changes

### app/admin/router.py
- Import \FileResponse\ and \os\
- Compute \_DATA_DIR\ / \_MODEL_DIR\ from \DATA_DIR\ env var (same pattern as \main.py\)
- New \GET /admin/download-model\ endpoint: session-authenticated, finds the latest \coffee_classifier_*.joblib\ in the models directory and serves it as a file download
- Redirects back to dashboard with a message if no model exists

### app/admin/templates/dashboard.html
- Added a **Download Model** button (outline style) in the Model Training card grid, between Train and Upload
- Button is hidden by default (\display:none\) and shown/hidden dynamically by \loadModelInfo()\:
  - **Shown** when model info loads successfully and a model is loaded
  - **Hidden** when no model is loaded or classifier is unreachable

## How it works
1. User logs into the admin panel
2. If a trained model exists, the Download Model button appears in the Model Training card
3. Clicking the button triggers a direct file download of the latest \.joblib\ model file
4. The endpoint reads from the shared \DATA_DIR/models\ volume (no classifier service changes needed)