### PR TITLE
fix: correct DATA_DIR fallback path for model download

### DIFF
--- a/app/admin/router.py
+++ b/app/admin/router.py
@@ -16,7 +16,7 @@ from config import _DESCRIPTIONS, config
 
 logger = logging.getLogger("rpicoffee.admin")
 
-_DATA_DIR = Path(os.environ.get("DATA_DIR", str(Path(__file__).resolve().parent.parent.parent / "data")))
+_DATA_DIR = Path(os.environ.get("DATA_DIR", str(Path(__file__).resolve().parent.parent / "data")))
 _MODEL_DIR = _DATA_DIR / "models"
 
 router = APIRouter()


### PR DESCRIPTION
Use .parent.parent (app/ -> app/data/) matching the pattern in training_data.py and main.py. The previous .parent.parent.parent resolved one level too high, missing the app/data/models directory.