### PR TITLE
docs: split and improve project documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,9 @@ rpiCoffee/
 │   ├── admin/                  # Admin panel (routes + Jinja2 templates)
 │   ├── sensor/                 # Sensor abstraction (mock, picoquake, serial)
 │   └── services/               # HTTP clients for backend microservices
+├── docs/                       # Documentation
+│   ├── setup-raspberry-pi.md   # Raspberry Pi installation & operations guide
+│   └── local-development.md    # Local development & contribution guide
 ├── services/
 │   ├── classifier/             # ML coffee classifier (Docker, scikit-learn :8001)
 │   ├── llm/                    # Fine-tuned LLM inference server (Docker, llama-cpp :8002)
@@ -106,26 +109,23 @@ Always code against the shared sensor interface, not concrete reader classes.
 
 ## Development Workflow
 
-### Local development (Windows / macOS, no hardware)
+See the dedicated guides for full details:
+
+- **[Local Development](../docs/local-development.md)** — Windows/macOS setup, mock sensor, testing, contribution guidelines
+- **[Setup on Raspberry Pi](../docs/setup-raspberry-pi.md)** — Installation, configuration, management scripts, systemd
+
+### Quick reference
 
 ```bash
-python -m venv .venv && .venv\Scripts\activate   # Windows
+# Local development (Windows)
+python -m venv .venv && .venv\Scripts\activate
 pip install -r app/requirements.txt
 pip install -r services/classifier/requirements.txt
-
-# Start everything (mock sensor, no TTS)
-run-local.bat
+docker compose --profile classifier --profile llm up -d
+run-app-local.bat
 ```
 
 Set `SENSOR_MODE=mock` (the default) to replay CSV samples without hardware.
-
-### Raspberry Pi
-
-```bash
-./setup.sh    # Interactive installer (phases 0–8)
-./start.sh    # Start Docker services + native app
-./status.sh   # Health-check dashboard
-```
 
 ### Docker Compose profiles
 

--- a/README.md
+++ b/README.md
@@ -54,142 +54,12 @@ An alternative LLM backend uses the **Hailo AI HAT+ 2** NPU accelerator via `hai
 | USB speaker (e.g. Jabra) | Play TTS audio | Recommended |
 | Touchscreen display | Kiosk UI with virtual keyboard | Optional |
 
-## Quick Start — Raspberry Pi
+## Get Started
 
-```bash
-# 1. Clone the repository
-git clone https://github.com/jenschristianschroder/rpiCoffee.git
-cd rpiCoffee
-
-# 2. Run the interactive installer (8 phases)
-./setup.sh
-
-# 3. Start all services
-./start.sh
-
-# 4. Open the kiosk UI
-# http://<pi-ip>:8080
-```
-
-### What `setup.sh` does
-
-| Phase | Description |
+| Guide | Description |
 |-------|-------------|
-| 0 | Pre-flight checks (architecture, disk space, internet) |
-| 1 | System dependencies (Docker, Python 3, Chromium, build tools) |
-| 2 | `.env` configuration + optional Dataverse credentials |
-| 3 | Python virtual environment + pip install |
-| 4 | Model downloads (LLM GGUF ~350 MB, TTS voice ~100 MB) |
-| 5 | Docker image builds (classifier, LLM, TTS, remote-save) |
-| 6 | USB device setup (udev rules for PicoQuake, autosuspend disabled) |
-| 7 | Optional systemd services + Chromium kiosk mode |
-| 8 | Data directory bootstrap |
-
-### Management scripts
-
-| Script | Description |
-|--------|-------------|
-| `start.sh` | Start Docker services (by profile), wait for health checks, launch app natively |
-| `stop.sh` | Stop app + Docker services + hailo-ollama |
-| `status.sh` | Full status dashboard with health checks (supports `--json`) |
-
-## Quick Start — Local Development (Windows)
-
-No hardware required — the mock sensor replays sample CSV files.
-
-```bash
-# 1. Create and activate a virtual environment
-python -m venv .venv
-.venv\Scripts\activate
-pip install -r app\requirements.txt
-pip install -r services\classifier\requirements.txt
-pip install -r services\llm\requirements-serve.txt
-
-# 2. Start all services in separate terminal windows
-run-local.bat
-```
-
-This starts the classifier, LLM server, and main app with `SENSOR_MODE=mock`. TTS is skipped on Windows (requires Piper/Linux).
-
-**Alternative** — run only the main app natively while backend services run in Docker (useful for USB sensor testing):
-
-```bash
-# Start Docker backends
-docker compose --profile classifier --profile llm --profile tts up -d
-
-# Run the app on the host
-run-app-local.bat
-```
-
-## Configuration
-
-rpiCoffee uses a three-layer configuration system (highest priority last):
-
-1. **Hardcoded defaults** (in `app/config.py`)
-2. **`.env` file** values
-3. **`data/settings.json`** — persisted at runtime via the admin panel
-
-### Key Environment Variables
-
-#### Services
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `CLASSIFIER_ENABLED` | `true` | Enable the ML classifier service |
-| `CLASSIFIER_ENDPOINT` | `http://classifier:8001` | Classifier service URL |
-| `LLM_ENABLED` | `true` | Enable the LLM text generation service |
-| `LLM_BACKEND` | `llama-cpp` | `llama-cpp` for CPU or `ollama` for Hailo AI HAT+ |
-| `LLM_ENDPOINT` | `http://llm:8002` | LLM service URL (llama-cpp) |
-| `LLM_OLLAMA_ENDPOINT` | `http://localhost:8000` | Ollama endpoint (Hailo) |
-| `TTS_ENABLED` | `true` | Enable text-to-speech |
-| `TTS_ENDPOINT` | `http://tts:5050` | TTS service URL |
-| `REMOTE_SAVE_ENABLED` | `true` | Enable Dataverse persistence |
-| `REMOTE_SAVE_ENDPOINT` | `http://remote-save:7000` | Remote save service URL |
-
-#### Sensor
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SENSOR_MODE` | `mock` | `mock`, `picoquake`, or `serial` |
-| `SENSOR_DEVICE_ID` | `cf79` | PicoQuake USB device ID (last 4 hex chars of serial) |
-| `SENSOR_SAMPLE_RATE_HZ` | `100` | Sensor readings per second |
-| `SENSOR_DURATION_S` | `30` | Seconds of data to capture per brew |
-| `SENSOR_VIBRATION_THRESHOLD` | `0.15` | Accelerometer RMS threshold (g) for auto-trigger |
-| `SENSOR_AUTO_TRIGGER` | `true` | Automatically start pipeline on vibration detection |
-| `SENSOR_TRIGGER_SOURCES` | `accel` | Trigger source: `accel`, `gyro`, or `both` |
-| `SENSOR_WARMUP_S` | `5` | Seconds to ignore triggers after sensor start |
-| `SENSOR_COOLDOWN_S` | `10` | Seconds to wait between captures |
-
-#### LLM Generation
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `LLM_MAX_TOKENS` | `256` | Maximum tokens per generation |
-| `LLM_TEMPERATURE` | `0.7` | Sampling temperature (0.0–2.0) |
-| `LLM_TOP_P` | `0.9` | Nucleus sampling threshold (0.0–1.0) |
-| `LLM_SYSTEM_MESSAGE` | *(coffee commentator prompt)* | System prompt controlling tone/style |
-| `LLM_KEEP_ALIVE` | `-1` | Ollama keep_alive: -1=forever, 0=unload, or seconds |
-
-#### Auth & UI
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SECRET_KEY` | `change-me-to-a-random-string` | Session signing key |
-| `ADMIN_PASSWORD` | `1234` | Initial admin password (hashed on first run) |
-| `VIRTUAL_KEYBOARD_ENABLED` | `false` | On-screen keyboard for touchscreen kiosk |
-
-## Admin Panel
-
-The web-based admin panel at `/admin` provides:
-
-- **Service configuration** — enable/disable services, change endpoints, LLM parameters
-- **Sensor settings** — mode, thresholds, trigger sources, warmup/cooldown
-- **Training data management** — view, delete, and promote training CSV files
-- **Model management** — trigger training, upload models, view model info
-- **System message editor** — customize the LLM personality
-- **Password management** — change the admin PIN
-
-Access is protected by a PIN (default: `1234`). Sessions expire after 10 minutes of inactivity.
+| **[Setup on Raspberry Pi](docs/setup-raspberry-pi.md)** | Full installation, configuration, management scripts, systemd auto-start, and troubleshooting |
+| **[Local Development](docs/local-development.md)** | Development environment setup, mock sensor, testing, architecture patterns, and contribution guidelines |
 
 ## Services
 
@@ -212,6 +82,9 @@ rpiCoffee/
 │   ├── admin/                  # Admin panel (routes + Jinja2 templates)
 │   ├── sensor/                 # Sensor abstraction (mock, picoquake, serial)
 │   └── services/               # HTTP clients for backend services
+├── docs/                       # Documentation
+│   ├── setup-raspberry-pi.md   # Raspberry Pi installation & operations guide
+│   └── local-development.md    # Local development & contribution guide
 ├── services/
 │   ├── classifier/             # ML coffee classifier (Docker)
 │   ├── llm/                    # Fine-tuned LLM server (Docker)
@@ -222,7 +95,6 @@ rpiCoffee/
 ├── setup.sh                    # Interactive Raspberry Pi installer
 ├── start.sh / stop.sh          # Service lifecycle management
 ├── status.sh                   # Health check dashboard
-├── run-local.bat               # Windows: start all services locally
 └── run-app-local.bat           # Windows: app on host + Docker backends
 ```
 

--- a/app/README.md
+++ b/app/README.md
@@ -164,6 +164,9 @@ Settings changes that affect the sensor (mode, device ID, thresholds, etc.) auto
 
 ## Running Locally
 
+> For full setup instructions see the [Local Development guide](../docs/local-development.md).
+
+
 ```bash
 # From the repository root
 cd app

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,205 @@
+# Local Development
+
+Guide for setting up a development environment, running rpiCoffee without hardware, and contributing to the project.
+
+> **Back to [project overview](../README.md)** · See also [Setup on Raspberry Pi](setup-raspberry-pi.md)
+
+## Prerequisites
+
+- **Python 3.11+**
+- **Docker Desktop** (for backend services)
+- **Git**
+
+No Raspberry Pi, sensor, or speaker hardware is required — the mock sensor replays sample CSV files and TTS can be skipped on Windows.
+
+## Getting Started
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/jenschristianschroder/rpiCoffee.git
+cd rpiCoffee
+
+# 2. Create and activate a virtual environment
+python -m venv .venv
+.venv\Scripts\activate          # Windows
+# source .venv/bin/activate     # macOS / Linux
+
+# 3. Install dependencies
+pip install -r app\requirements.txt
+pip install -r services\classifier\requirements.txt
+pip install -r services\llm\requirements-serve.txt
+```
+
+## Running the Application
+
+### Option A: Docker backends + native app (recommended)
+
+Run the backend services in Docker and the main app natively. This is the closest to the production architecture and gives you hot-reload on the app:
+
+```bash
+# Start backend services
+docker compose --profile classifier --profile llm --profile tts up -d
+
+# Run the app on the host with hot-reload
+run-app-local.bat
+```
+
+The app runs at **http://localhost:8080** with `SENSOR_MODE=mock` by default.
+
+`run-app-local.bat` points the app at Docker service endpoints on `localhost`, sets up the data directory, and launches uvicorn with auto-reload.
+
+### Option B: Everything natively (no Docker)
+
+If you don't want to use Docker at all, you can run each service in a separate terminal:
+
+**Terminal 1 — Classifier:**
+
+```bash
+cd services\classifier
+uvicorn main:app --host 0.0.0.0 --port 8001
+```
+
+**Terminal 2 — LLM server:**
+
+```bash
+cd services\llm
+python server.py --model coffee-gguf/coffee-Q4_K_M.gguf --port 8002
+```
+
+**Terminal 3 — Main app:**
+
+```bash
+cd app
+set SENSOR_MODE=mock
+set CLASSIFIER_ENDPOINT=http://localhost:8001
+set LLM_ENDPOINT=http://localhost:8002
+uvicorn main:app --host 0.0.0.0 --port 8080 --reload
+```
+
+> **Note:** TTS requires Piper, which only runs on Linux. On Windows, set `TTS_ENABLED=false` or leave TTS out — the pipeline will skip the speech stage gracefully.
+
+## Configuration for Local Dev
+
+The mock sensor mode is the default, so no `.env` file is strictly required for basic local development. Key settings:
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `SENSOR_MODE` | `mock` | Replays CSV samples from `data/` |
+| `CLASSIFIER_ENDPOINT` | `http://classifier:8001` | Override to `http://localhost:8001` when running natively (done automatically by `run-app-local.bat`) |
+| `LLM_ENDPOINT` | `http://llm:8002` | Override to `http://localhost:8002` |
+| `TTS_ENABLED` | `true` | Set to `false` on Windows |
+
+For the full list of environment variables, see the [Configuration](setup-raspberry-pi.md#configuration) section in the Raspberry Pi guide.
+
+## Sensor Modes
+
+Three sensor modes are supported, selected via the `SENSOR_MODE` environment variable:
+
+| Mode | Class | Use case |
+|------|-------|---------|
+| `mock` | `MockReader` | Local development — replays sample CSVs from `data/` |
+| `picoquake` | `PicoQuakeReader` | Real PicoQuake USB IMU on Raspberry Pi |
+| `serial` | `SerialReader` | Generic serial IMU |
+
+Always code against the shared sensor interface in `app/sensor/reader.py`, not concrete reader classes.
+
+## Testing Locally
+
+### Triggering a brew
+
+With the app running in mock mode:
+
+1. Open **http://localhost:8080** in your browser (kiosk UI)
+2. Click the **Brew** button, or
+3. Send an API request:
+
+```bash
+curl -X POST http://localhost:8080/api/brew
+```
+
+The mock sensor replays a sample CSV file, the classifier identifies the coffee type, and the LLM generates a witty comment. On Windows (without TTS), the audio step is skipped.
+
+### Streaming pipeline events
+
+```bash
+curl http://localhost:8080/api/brew/stream
+```
+
+Returns Server-Sent Events (SSE) for each pipeline stage as it completes.
+
+### Health checks
+
+```bash
+curl http://localhost:8080/health           # Main app
+curl http://localhost:8001/health           # Classifier
+curl http://localhost:8002/health           # LLM
+```
+
+## Architecture Patterns
+
+### Configuration system
+
+rpiCoffee uses a three-layer config system (highest priority last):
+
+1. Hardcoded defaults in `app/config.py` (`_DEFAULTS` dict)
+2. `.env` file values (loaded via `python-dotenv`)
+3. `data/settings.json` — runtime overrides persisted by the admin panel
+
+Always read settings via the `config` object:
+
+```python
+from config import config
+
+value = config.get("SENSOR_DURATION_S")        # typed read
+config.set("LLM_TEMPERATURE", 0.8)             # runtime update (persisted)
+```
+
+### Service clients
+
+Each backend service has a thin async HTTP client in `app/services/`. Follow this pattern when adding a new service:
+
+```python
+import httpx
+
+class MyServiceClient:
+    def __init__(self, endpoint: str, enabled: bool) -> None:
+        self.endpoint = endpoint
+        self.enabled = enabled
+
+    async def call(self, payload: dict) -> dict:
+        if not self.enabled:
+            return {}
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(f"{self.endpoint}/route", json=payload)
+            response.raise_for_status()
+            return response.json()
+```
+
+### Sensor abstraction
+
+Always code against the shared sensor interface, not concrete reader classes. See `app/sensor/reader.py` for the base class.
+
+## Adding a New Backend Service
+
+1. Create `services/<name>/` with `app.py`, `requirements.txt`, `Dockerfile`, `.env.example`, and `README.md`
+2. Add a Docker Compose service entry in `docker-compose.yml` with an appropriate profile
+3. Add a corresponding client in `app/services/<name>_client.py`
+4. Register the client in `app/main.py` and wire it into `app/pipeline.py` if it is a pipeline stage
+5. Expose configuration keys with defaults in `app/config.py` (`_DEFAULTS`)
+
+## Code Conventions
+
+- Use `from __future__ import annotations` at the top of every module
+- Use **full type hints** on all function signatures and class attributes
+- Prefer `async def` / `await` for I/O-bound operations (HTTP calls, file I/O, sensor reads)
+- Use `pathlib.Path` instead of bare `os.path` string manipulation
+- Use `logging.getLogger(__name__)` for per-module loggers; never `print()` for diagnostic output
+- Configuration values must be read through the `config` singleton, not accessed directly from `os.environ`
+
+## Pull Request Guidelines
+
+- Keep PRs focused on a single concern
+- Include a brief description of **why** the change is needed and **what** was changed
+- Update the relevant README (root or service-level) if behaviour or configuration changes
+- Test locally in `mock` sensor mode before submitting
+- For new pipeline stages or sensor modes, add a corresponding mock/stub so the feature works without hardware

--- a/docs/setup-raspberry-pi.md
+++ b/docs/setup-raspberry-pi.md
@@ -1,0 +1,303 @@
+# Setup on Raspberry Pi
+
+Step-by-step guide for installing, configuring, and running rpiCoffee on a Raspberry Pi.
+
+> **Back to [project overview](../README.md)** · See also [Local Development](local-development.md)
+
+## Prerequisites
+
+| Component | Purpose | Required? |
+|-----------|---------|-----------|
+| Raspberry Pi 5 (4–8 GB) | Main compute platform | Yes (Pi 4 also works) |
+| PicoQuake USB sensor | 6-axis IMU vibration sensing | No — mock mode replays CSV samples |
+| Hailo AI HAT+ 2 | NPU-accelerated LLM inference | No — llama-cpp CPU fallback |
+| USB speaker (e.g. Jabra) | Play TTS audio | Recommended |
+| Touchscreen display | Kiosk UI with virtual keyboard | Optional |
+
+**Software:**
+
+- Raspberry Pi OS (64-bit, Bookworm or Trixie recommended)
+- Internet connection (for initial setup only — runs offline after)
+- At least **5 GB** of free disk space
+
+## Quick Start
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/jenschristianschroder/rpiCoffee.git
+cd rpiCoffee
+
+# 2. Run the interactive installer (8 phases)
+./setup.sh
+
+# 3. Start all services
+./start.sh
+
+# 4. Open the kiosk UI
+# http://<pi-ip>:8080
+```
+
+## What `setup.sh` Does
+
+The installer runs 8 phases interactively. It takes roughly 30–45 minutes, dominated by Docker image builds.
+
+| Phase | Description | Details |
+|-------|-------------|---------|
+| **0** | Pre-flight checks | Validates ARM64 architecture, detects Pi model, checks ≥5 GB disk space, tests internet |
+| **1** | System dependencies | Installs Docker, Python 3, Chromium, build tools; adds user to `docker` and `dialout` groups |
+| **2** | Environment configuration | Generates `.env` from `.env.example`, creates random `SECRET_KEY`, prompts for admin password, sensor mode, service toggles, optional Dataverse credentials |
+| **3** | Python virtual environment | Creates `.venv`, installs app dependencies via pip |
+| **4** | Model downloads | LLM GGUF model (~350 MB), TTS voice (~100 MB); optional `hailo-ollama` model pull |
+| **5** | Docker image builds | Builds images for enabled services (classifier, LLM, TTS, remote-save). The LLM image can take 15–30 min on ARM64 |
+| **6** | USB device setup | Installs udev rules for PicoQuake sensor, disables USB autosuspend to prevent connection drops |
+| **7** | Systemd auto-start (optional) | Creates systemd units for Docker services, app, hailo-ollama, and Chromium kiosk mode |
+| **8** | Data directory bootstrap | Creates `data/` directories and copies seed CSV samples |
+
+> **Tip:** If setup fails at a particular phase, fix the issue and re-run `./setup.sh` — it is idempotent and will skip already-completed steps.
+
+## Management Scripts
+
+| Script | Description |
+|--------|-------------|
+| `start.sh` | Starts Docker services (by profile), waits for health checks, launches app natively |
+| `stop.sh` | Stops app (uvicorn) + Docker services + hailo-ollama |
+| `status.sh` | Full status dashboard with health checks (supports `--json` for machine-readable output) |
+
+### Starting services
+
+```bash
+./start.sh
+```
+
+`start.sh` reads your `.env` to determine which services are enabled, starts only those Docker profiles, waits for each service's `/health` endpoint to respond, then launches the main app via uvicorn.
+
+### Stopping services
+
+```bash
+./stop.sh
+```
+
+### Checking status
+
+```bash
+# Pretty table output (default)
+./status.sh
+
+# Machine-readable JSON
+./status.sh --json
+```
+
+`status.sh` checks all service health endpoints, Docker container states, systemd unit status, and USB sensor connectivity.
+
+## Configuration
+
+rpiCoffee uses a three-layer configuration system (highest priority last):
+
+1. **Hardcoded defaults** in `app/config.py`
+2. **`.env` file** values
+3. **`data/settings.json`** — persisted at runtime via the admin panel
+
+### Key Environment Variables
+
+#### Services
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLASSIFIER_ENABLED` | `true` | Enable the ML classifier service |
+| `CLASSIFIER_ENDPOINT` | `http://classifier:8001` | Classifier service URL |
+| `LLM_ENABLED` | `true` | Enable the LLM text generation service |
+| `LLM_BACKEND` | `llama-cpp` | `llama-cpp` for CPU or `ollama` for Hailo AI HAT+ |
+| `LLM_ENDPOINT` | `http://llm:8002` | LLM service URL (llama-cpp) |
+| `LLM_OLLAMA_ENDPOINT` | `http://localhost:8000` | Ollama endpoint (Hailo) |
+| `TTS_ENABLED` | `true` | Enable text-to-speech |
+| `TTS_ENDPOINT` | `http://tts:5050` | TTS service URL |
+| `REMOTE_SAVE_ENABLED` | `true` | Enable Dataverse persistence |
+| `REMOTE_SAVE_ENDPOINT` | `http://remote-save:7000` | Remote save service URL |
+
+#### Sensor
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SENSOR_MODE` | `mock` | `mock`, `picoquake`, or `serial` |
+| `SENSOR_DEVICE_ID` | `cf79` | PicoQuake USB device ID (last 4 hex chars of serial) |
+| `SENSOR_SAMPLE_RATE_HZ` | `100` | Sensor readings per second |
+| `SENSOR_DURATION_S` | `30` | Seconds of data to capture per brew |
+| `SENSOR_VIBRATION_THRESHOLD` | `0.15` | Accelerometer RMS threshold (g) for auto-trigger |
+| `SENSOR_AUTO_TRIGGER` | `true` | Automatically start pipeline on vibration detection |
+| `SENSOR_TRIGGER_SOURCES` | `accel` | Trigger source: `accel`, `gyro`, or `both` |
+| `SENSOR_WARMUP_S` | `5` | Seconds to ignore triggers after sensor start |
+| `SENSOR_COOLDOWN_S` | `10` | Seconds to wait between captures |
+
+#### LLM Generation
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LLM_MAX_TOKENS` | `256` | Maximum tokens per generation |
+| `LLM_TEMPERATURE` | `0.7` | Sampling temperature (0.0–2.0) |
+| `LLM_TOP_P` | `0.9` | Nucleus sampling threshold (0.0–1.0) |
+| `LLM_SYSTEM_MESSAGE` | *(coffee commentator prompt)* | System prompt controlling tone/style |
+| `LLM_KEEP_ALIVE` | `-1` | Ollama keep_alive: -1=forever, 0=unload, or seconds |
+
+#### Auth & UI
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SECRET_KEY` | `change-me-to-a-random-string` | Session signing key |
+| `ADMIN_PASSWORD` | `1234` | Initial admin password (hashed on first run) |
+| `VIRTUAL_KEYBOARD_ENABLED` | `false` | On-screen keyboard for touchscreen kiosk |
+
+> **Security:** Change the default `SECRET_KEY` and `ADMIN_PASSWORD` before deploying to a network-accessible Pi. Never commit secrets to version control — use `.env` (gitignored).
+
+## Admin Panel
+
+The web-based admin panel at `/admin` provides:
+
+- **Service configuration** — enable/disable services, change endpoints, LLM parameters
+- **Sensor settings** — mode, thresholds, trigger sources, warmup/cooldown
+- **Training data management** — view, delete, and promote training CSV files
+- **Model management** — trigger training, upload models, view model info
+- **System message editor** — customize the LLM personality
+- **Password management** — change the admin PIN
+
+Access is protected by a PIN (default: `1234`). Sessions expire after 10 minutes of inactivity.
+
+## USB Sensor Setup
+
+When using `SENSOR_MODE=picoquake`, the PicoQuake USB sensor needs udev rules for non-root access. These are installed automatically by `setup.sh` (phase 6), but you can set them up manually:
+
+```bash
+# Create udev rule for PicoQuake USB access
+echo 'SUBSYSTEM=="tty", ATTRS{idProduct}=="000a", ATTRS{idVendor}=="2e8a", MODE="0666", SYMLINK+="picoquake"' \
+  | sudo tee /etc/udev/rules.d/99-picoquake.rules
+
+# Disable USB autosuspend (prevents connection drops)
+echo 'ACTION=="add", SUBSYSTEM=="usb", ATTRS{idProduct}=="000a", ATTRS{idVendor}=="2e8a", TEST=="power/control", ATTR{power/control}="on"' \
+  | sudo tee /etc/udev/rules.d/99-picoquake-power.rules
+
+# Reload rules
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+Ensure your user is in the `dialout` group:
+
+```bash
+sudo usermod -aG dialout $USER
+# Log out and back in for the change to take effect
+```
+
+## Systemd Auto-Start
+
+`setup.sh` (phase 7) can create systemd units so that rpiCoffee starts automatically on boot. The following units are created:
+
+| Unit | Type | Description |
+|------|------|-------------|
+| `rpicoffee-services` | oneshot | Starts Docker Compose services with enabled profiles |
+| `rpicoffee-app` | simple | Runs the FastAPI app via uvicorn (depends on services) |
+| `rpicoffee-kiosk` | simple | Launches Chromium in kiosk mode (depends on app) |
+| `rpicoffee-hailo-ollama` | simple | Runs hailo-ollama (only when LLM backend = ollama) |
+
+### Manual management
+
+```bash
+# Check status
+sudo systemctl status rpicoffee-app
+
+# Restart the app
+sudo systemctl restart rpicoffee-app
+
+# View logs
+journalctl -u rpicoffee-app -f
+
+# Disable auto-start
+sudo systemctl disable rpicoffee-app rpicoffee-services rpicoffee-kiosk
+```
+
+## Hailo AI HAT+ Setup (Optional)
+
+The Hailo AI HAT+ 2 provides NPU-accelerated LLM inference via `hailo-ollama` as an alternative to the CPU-based llama-cpp server.
+
+### Installation
+
+1. Download the `hailo_gen_ai_model_zoo` `.deb` package from [hailo.ai/developer-zone](https://hailo.ai/developer-zone/)
+2. Place the `.deb` file in the rpiCoffee project root
+3. Run `setup.sh` — it will detect and install the package automatically
+
+Or install manually:
+
+```bash
+sudo apt install ./hailo_gen_ai_model_zoo_*.deb
+```
+
+### Configuration
+
+Set these in your `.env`:
+
+```bash
+LLM_BACKEND=ollama
+LLM_OLLAMA_ENDPOINT=http://localhost:8000
+LLM_MODEL=qwen2:1.5b
+```
+
+When using the Ollama backend, the LLM Docker container is **not** built or started — inference runs directly on the Hailo NPU via `hailo-ollama`.
+
+## Docker Compose Profiles
+
+Backend services are opt-in via Docker Compose profiles. Only enabled services are started:
+
+```bash
+# Start specific services
+docker compose --profile classifier --profile llm --profile tts up -d
+
+# Available profiles: classifier, llm, tts, remote-save
+```
+
+All containers share the `coffee-net` bridge network and use an `unless-stopped` restart policy.
+
+## Troubleshooting
+
+### Docker build fails on Pi 4 (out of memory)
+
+The LLM Docker image build compiles llama.cpp from source and can exceed available memory on a Pi 4 (4 GB). Try:
+
+```bash
+# Reduce parallel make jobs
+export DOCKER_BUILDKIT=1
+docker compose --profile llm build --build-arg CMAKE_BUILD_PARALLEL_LEVEL=1
+```
+
+### PicoQuake sensor not detected
+
+1. Check the USB connection: `ls /dev/ttyACM*`
+2. Verify udev rules are installed: `cat /etc/udev/rules.d/99-picoquake.rules`
+3. Ensure your user is in the `dialout` group: `groups $USER`
+4. Try unplugging and reconnecting the sensor
+
+### Service fails health check on startup
+
+`start.sh` waits up to 120 seconds (60 × 2s) for each service. If a service consistently fails:
+
+```bash
+# Check Docker container logs
+docker compose logs classifier
+docker compose logs llm
+
+# Check if the container is running
+docker compose ps
+```
+
+### TTS has no audio output
+
+1. Verify the speaker is connected: `aplay -l`
+2. Test audio output: `speaker-test -t wav -c 2`
+3. Check PipeWire is running: `systemctl --user status pipewire`
+
+### App starts but kiosk doesn't open
+
+The kiosk unit waits for the X display and PipeWire audio before launching Chromium. Check:
+
+```bash
+journalctl -u rpicoffee-kiosk -f
+```
+
+Ensure you are running a desktop environment (Raspberry Pi OS with Desktop, not Lite).


### PR DESCRIPTION
## Summary

Splits the monolithic root README into three focused documents for better clarity and onboarding, as proposed in #54.

## Changes

### New files
- **`docs/setup-raspberry-pi.md`**  Complete Raspberry Pi guide: prerequisites, setup.sh walkthrough (all 8 phases), configuration (full env var reference), management scripts, admin panel, USB sensor setup, systemd auto-start, Hailo AI HAT+ setup, Docker Compose profiles, and troubleshooting section
- **`docs/local-development.md`**  Developer guide: prerequisites, getting started, two options for running locally (Docker backends + native app, or everything native), configuration for local dev, sensor modes, testing locally (triggering brews, streaming events, health checks), architecture patterns, code conventions, adding new services, and PR guidelines

### Modified files
- **`README.md`**  Slimmed down to a concise overview: keeps project description, How It Works, architecture diagram, hardware table, services table, and project structure. Replaces setup/config/admin sections with a Get Started table linking to the two new guides. Updated project structure tree to include `docs/` directory
- **`.github/copilot-instructions.md`**  Updated repository structure to include `docs/` directory; updated Development Workflow section to reference the new guides instead of inline instructions
- **`app/README.md`**  Added cross-link to the local development guide in the Running Locally section

## What stays the same
- All service-level READMEs unchanged (classifier, llm, tts, remote-save)
- No content lost  every section from the original README exists in exactly one of the three documents
- Architecture Mermaid diagram remains in root README
- All configuration reference tables preserved (authoritative home now in `docs/setup-raspberry-pi.md`)

Closes #54
Closes #55
Closes #56