### PR TITLE
feat: service registry with pipeline configuration and API

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules."""

--- a/app/api/registry_routes.py
+++ b/app/api/registry_routes.py
@@ -1,0 +1,149 @@
+"""API routes for the service registry and pipeline configuration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from models.registry import PipelineStep
+from registry import registry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/registry", tags=["registry"])
+
+
+# ── Request models ───────────────────────────────────────────────
+
+class RegisterServiceRequest(BaseModel):
+    name: str = Field(..., description="Unique service name (kebab-case)")
+    endpoint: str = Field(..., description="Base URL of the service")
+
+
+class SetEnabledRequest(BaseModel):
+    enabled: bool
+
+
+class PipelineUpdateRequest(BaseModel):
+    pipeline: list[PipelineStep]
+
+
+# ── Service CRUD ─────────────────────────────────────────────────
+
+@router.get("/services")
+async def list_services() -> list[dict[str, Any]]:
+    """List all registered services with their manifests."""
+    return [
+        {
+            "name": reg.name,
+            "endpoint": reg.endpoint,
+            "enabled": reg.enabled,
+            "registered_at": reg.registered_at.isoformat(),
+            "manifest": reg.manifest.model_dump() if reg.manifest else None,
+        }
+        for reg in registry.list_all()
+    ]
+
+
+@router.post("/services", status_code=201)
+async def register_service(req: RegisterServiceRequest) -> dict[str, Any]:
+    """Register a new service by name + endpoint.  Fetches its manifest."""
+    existing = registry.get(req.name)
+    if existing:
+        raise HTTPException(status_code=409, detail=f"Service '{req.name}' is already registered")
+    reg = await registry.register(req.name, req.endpoint)
+    return {
+        "name": reg.name,
+        "endpoint": reg.endpoint,
+        "enabled": reg.enabled,
+        "manifest": reg.manifest.model_dump() if reg.manifest else None,
+    }
+
+
+@router.delete("/services/{name}", status_code=204)
+async def unregister_service(name: str) -> None:
+    """Remove a registered service and any pipeline steps referencing it."""
+    if not registry.get(name):
+        raise HTTPException(status_code=404, detail=f"Service '{name}' not found")
+    registry.unregister(name)
+
+
+@router.post("/services/{name}/refresh")
+async def refresh_manifest(name: str) -> dict[str, Any]:
+    """Re-fetch the manifest for a registered service."""
+    if not registry.get(name):
+        raise HTTPException(status_code=404, detail=f"Service '{name}' not found")
+    manifest = await registry.refresh_manifest(name)
+    return {"name": name, "manifest": manifest.model_dump() if manifest else None}
+
+
+@router.patch("/services/{name}/enabled")
+async def set_service_enabled(name: str, req: SetEnabledRequest) -> dict[str, Any]:
+    """Enable or disable a registered service."""
+    if not registry.get(name):
+        raise HTTPException(status_code=404, detail=f"Service '{name}' not found")
+    registry.set_enabled(name, req.enabled)
+    return {"name": name, "enabled": req.enabled}
+
+
+# ── Health ───────────────────────────────────────────────────────
+
+@router.get("/health")
+async def health_check_all() -> dict[str, dict[str, Any]]:
+    """Run health checks on all registered services."""
+    return await registry.health_check_all()
+
+
+@router.get("/health/{name}")
+async def health_check(name: str) -> dict[str, Any]:
+    """Run a health check on a single service."""
+    if not registry.get(name):
+        raise HTTPException(status_code=404, detail=f"Service '{name}' not found")
+    return await registry.health_check(name)
+
+
+# ── Pipeline configuration ───────────────────────────────────────
+
+@router.get("/pipeline")
+async def get_pipeline() -> dict[str, Any]:
+    """Return the current pipeline configuration."""
+    cfg = registry.get_pipeline_config()
+    return {
+        "pipeline": [step.model_dump() for step in cfg.pipeline],
+        "services": {
+            name: {
+                "name": reg.name,
+                "endpoint": reg.endpoint,
+                "enabled": reg.enabled,
+                "manifest": reg.manifest.model_dump() if reg.manifest else None,
+            }
+            for name, reg in cfg.services.items()
+        },
+    }
+
+
+@router.put("/pipeline")
+async def set_pipeline(req: PipelineUpdateRequest) -> dict[str, Any]:
+    """Replace the entire pipeline step configuration."""
+    # Validate all referenced services exist
+    for step in req.pipeline:
+        if not registry.get(step.service):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Step references unregistered service '{step.service}'",
+            )
+    registry.set_pipeline(req.pipeline)
+    return {"pipeline": [step.model_dump() for step in req.pipeline]}
+
+
+@router.post("/pipeline/validate")
+async def validate_pipeline() -> dict[str, Any]:
+    """Validate the current pipeline wiring and return any issues."""
+    issues = registry.validate_pipeline()
+    return {
+        "valid": len(issues) == 0,
+        "issues": issues,
+    }

--- a/app/config.py
+++ b/app/config.py
@@ -95,6 +95,8 @@ _DEFAULTS: dict[str, Any] = {
     # Remote save
     "REMOTE_SAVE_ENABLED": True,
     "REMOTE_SAVE_ENDPOINT": "http://remote-save:7000",
+    # Pipeline
+    "PIPELINE_CONFIG_PATH": str(_LOCAL_DATA_DIR / "pipeline.json"),
     # Data collection
     "DATA_COLLECT_ENABLED": False,
     "DATA_COLLECT_LABEL": "",

--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,9 @@ from fastapi.templating import Jinja2Templates
 
 from config import config
 from admin.router import router as admin_router
+from api.registry_routes import router as registry_router
 from pipeline import run_pipeline, run_pipeline_streaming
+from registry import registry
 from services.classifier_client import ClassifierClient
 from services.llm_client import LLMClient
 from services.ollama_client import OllamaClient
@@ -287,6 +289,11 @@ async def lifespan(app: FastAPI):
         endpoint = cfg.get(f"{svc}_ENDPOINT", "n/a")
         logger.info("  %s: %s (%s)", svc, "enabled" if enabled else "disabled", endpoint)
 
+    # Load service registry / pipeline config
+    registry.load()
+    logger.info("  Registry: %d services, %d pipeline steps",
+                len(registry.list_all()), len(registry.get_pipeline()))
+
     # Sensor mode
     sensor_mode = cfg.get("SENSOR_MODE", "mock")
     logger.info("  SENSOR: mode=%s", sensor_mode)
@@ -315,6 +322,7 @@ templates = Jinja2Templates(directory=str(Path(__file__).parent / "admin" / "tem
 
 # Routers
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
+app.include_router(registry_router)
 
 # Serve generated audio files
 app.mount("/audio", StaticFiles(directory=str(AUDIO_DIR)), name="audio")

--- a/app/models/registry.py
+++ b/app/models/registry.py
@@ -1,0 +1,49 @@
+"""Pydantic models for the service registry and pipeline configuration."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from models.manifest import ServiceManifest
+
+
+class ServiceRegistration(BaseModel):
+    """A registered pipeline service with its manifest and metadata."""
+
+    name: str = Field(..., description="Unique service identifier (kebab-case)")
+    endpoint: str = Field(..., description="Base URL of the service (e.g. http://classifier:8001)")
+    manifest: ServiceManifest | None = Field(None, description="Fetched service manifest")
+    enabled: bool = Field(True, description="Whether this service is available for pipeline use")
+    registered_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="Timestamp of initial registration",
+    )
+
+
+class PipelineStep(BaseModel):
+    """A single step in the pipeline configuration."""
+
+    service: str = Field(..., description="Name of the registered service to execute")
+    input_map: dict[str, str] = Field(
+        default_factory=dict,
+        description="Maps service input names to source references ($sensor.data, $classifier.label, etc.)",
+    )
+    on_failure: str = Field("skip", description="Failure policy: skip, halt, or retry")
+    retry_count: int = Field(1, ge=1, description="Number of retries when on_failure=retry")
+    enabled: bool = Field(True, description="Whether this step is active in the pipeline")
+
+
+class PipelineConfig(BaseModel):
+    """Full pipeline configuration: registered services + ordered steps."""
+
+    services: dict[str, ServiceRegistration] = Field(
+        default_factory=dict,
+        description="Map of service name → registration",
+    )
+    pipeline: list[PipelineStep] = Field(
+        default_factory=list,
+        description="Ordered list of pipeline steps to execute",
+    )

--- a/app/registry.py
+++ b/app/registry.py
@@ -1,0 +1,235 @@
+"""Service registry — manages registered pipeline services and pipeline configuration.
+
+Handles service registration, manifest fetching/validation, health checks,
+and persistence of the pipeline configuration to ``data/pipeline.json``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from config import config
+from models.manifest import ServiceManifest
+from models.registry import PipelineConfig, PipelineStep, ServiceRegistration
+
+logger = logging.getLogger(__name__)
+
+_MANIFEST_TIMEOUT = 5.0
+_HEALTH_TIMEOUT = 5.0
+
+
+class ServiceRegistry:
+    """Thread-safe singleton managing service registrations and pipeline config."""
+
+    def __init__(self) -> None:
+        self._config = PipelineConfig()
+        self._path: Path | None = None
+        self._loaded = False
+
+    # ── Persistence ──────────────────────────────────────────────
+
+    def load(self, path: Path | None = None) -> None:
+        """Load registry state from disk.  Creates default config if missing."""
+        self._path = path or Path(config.get("PIPELINE_CONFIG_PATH"))
+        if self._path.exists():
+            try:
+                raw = json.loads(self._path.read_text(encoding="utf-8"))
+                self._config = PipelineConfig.model_validate(raw)
+                logger.info("Loaded pipeline config from %s (%d services, %d steps)",
+                            self._path, len(self._config.services), len(self._config.pipeline))
+            except Exception:
+                logger.exception("Failed to load pipeline config from %s — using defaults", self._path)
+                self._config = PipelineConfig()
+        else:
+            logger.info("No pipeline config at %s — will create on first save", self._path)
+            self._config = PipelineConfig()
+        self._loaded = True
+
+    def save(self) -> None:
+        """Persist current state to disk."""
+        if self._path is None:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        data = json.loads(self._config.model_dump_json())
+        self._path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        logger.info("Saved pipeline config to %s", self._path)
+
+    # ── Service registration ─────────────────────────────────────
+
+    async def register(self, name: str, endpoint: str) -> ServiceRegistration:
+        """Register a service by fetching its manifest from ``GET /manifest``."""
+        endpoint = endpoint.rstrip("/")
+        manifest = await self._fetch_manifest(endpoint)
+        reg = ServiceRegistration(
+            name=name,
+            endpoint=endpoint,
+            manifest=manifest,
+            enabled=True,
+            registered_at=datetime.now(timezone.utc),
+        )
+        self._config.services[name] = reg
+        self.save()
+        logger.info("Registered service '%s' at %s", name, endpoint)
+        return reg
+
+    def unregister(self, name: str) -> None:
+        """Remove a service and any pipeline steps referencing it."""
+        self._config.services.pop(name, None)
+        self._config.pipeline = [s for s in self._config.pipeline if s.service != name]
+        self.save()
+        logger.info("Unregistered service '%s'", name)
+
+    def get(self, name: str) -> ServiceRegistration | None:
+        """Look up a registered service by name."""
+        return self._config.services.get(name)
+
+    def list_all(self) -> list[ServiceRegistration]:
+        """Return all registered services."""
+        return list(self._config.services.values())
+
+    def set_enabled(self, name: str, enabled: bool) -> None:
+        """Enable or disable a registered service."""
+        reg = self._config.services.get(name)
+        if reg:
+            reg.enabled = enabled
+            self.save()
+
+    # ── Manifest fetching ────────────────────────────────────────
+
+    async def refresh_manifest(self, name: str) -> ServiceManifest | None:
+        """Re-fetch the manifest for an already-registered service."""
+        reg = self._config.services.get(name)
+        if not reg:
+            return None
+        manifest = await self._fetch_manifest(reg.endpoint)
+        reg.manifest = manifest
+        self.save()
+        return manifest
+
+    async def _fetch_manifest(self, endpoint: str) -> ServiceManifest | None:
+        """Fetch and validate a manifest from a service endpoint."""
+        url = f"{endpoint}/manifest"
+        try:
+            async with httpx.AsyncClient(timeout=_MANIFEST_TIMEOUT) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+                return ServiceManifest.model_validate(resp.json())
+        except Exception:
+            logger.exception("Failed to fetch manifest from %s", url)
+            return None
+
+    # ── Health checks ────────────────────────────────────────────
+
+    async def health_check(self, name: str) -> dict[str, Any]:
+        """Check health of a single service using its manifest-declared endpoint."""
+        reg = self._config.services.get(name)
+        if not reg or not reg.manifest:
+            return {"status": "unknown", "error": "not registered or no manifest"}
+        ep = reg.manifest.endpoints.health
+        url = f"{reg.endpoint}{ep.path}"
+        try:
+            async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT) as client:
+                resp = await client.request(ep.method, url)
+                resp.raise_for_status()
+                return resp.json()
+        except Exception as exc:
+            return {"status": "unreachable", "error": str(exc)}
+
+    async def health_check_all(self) -> dict[str, dict[str, Any]]:
+        """Run parallel health checks on all registered services."""
+        if not self._config.services:
+            return {}
+        tasks = {
+            name: self.health_check(name)
+            for name in self._config.services
+        }
+        results: dict[str, dict[str, Any]] = {}
+        for name, coro in tasks.items():
+            results[name] = await coro
+        return results
+
+    # ── Pipeline configuration ───────────────────────────────────
+
+    def get_pipeline(self) -> list[PipelineStep]:
+        """Return the current ordered pipeline steps."""
+        return list(self._config.pipeline)
+
+    def set_pipeline(self, steps: list[PipelineStep]) -> None:
+        """Replace the entire pipeline configuration."""
+        self._config.pipeline = steps
+        self.save()
+
+    def get_pipeline_config(self) -> PipelineConfig:
+        """Return the full config (services + pipeline)."""
+        return self._config
+
+    def validate_pipeline(self) -> list[str]:
+        """Validate the current pipeline wiring.  Returns a list of issues."""
+        issues: list[str] = []
+        available_outputs: dict[str, set[str]] = {
+            "$sensor": {"data", "timestamp"},
+        }
+
+        for i, step in enumerate(self._config.pipeline):
+            reg = self._config.services.get(step.service)
+            if not reg:
+                issues.append(f"Step {i}: service '{step.service}' is not registered")
+                continue
+            if not reg.enabled:
+                issues.append(f"Step {i}: service '{step.service}' is disabled")
+            if not reg.manifest:
+                issues.append(f"Step {i}: service '{step.service}' has no manifest")
+                continue
+
+            # Check that all required inputs are mapped
+            for inp in reg.manifest.inputs:
+                if inp.required and inp.name not in step.input_map:
+                    issues.append(
+                        f"Step {i} ({step.service}): required input '{inp.name}' is not mapped"
+                    )
+
+            # Check that mapped sources actually exist
+            for inp_name, source_ref in step.input_map.items():
+                parts = source_ref.lstrip("$").split(".", 1)
+                if len(parts) != 2:
+                    issues.append(
+                        f"Step {i} ({step.service}): invalid source reference '{source_ref}'"
+                    )
+                    continue
+                src_service, src_key = parts
+                src_key_set = f"${src_service}"
+                if src_key_set not in available_outputs:
+                    issues.append(
+                        f"Step {i} ({step.service}): input '{inp_name}' references "
+                        f"'${src_service}' which hasn't produced output yet"
+                    )
+                elif src_key not in available_outputs[src_key_set]:
+                    issues.append(
+                        f"Step {i} ({step.service}): input '{inp_name}' references "
+                        f"'{source_ref}' but '{src_key}' is not a known output of '${src_service}'"
+                    )
+
+            # Validate failure mode
+            if step.on_failure not in ("skip", "halt", "retry"):
+                issues.append(
+                    f"Step {i} ({step.service}): invalid on_failure '{step.on_failure}'"
+                )
+
+            # Register this step's outputs for downstream steps
+            step_outputs = {
+                out.name for out in reg.manifest.outputs
+            }
+            available_outputs[f"${step.service}"] = step_outputs
+
+        return issues
+
+
+# ── Singleton ────────────────────────────────────────────────────
+registry = ServiceRegistry()

--- a/data/pipeline.json
+++ b/data/pipeline.json
@@ -1,0 +1,71 @@
+{
+  "services": {
+    "classifier": {
+      "name": "classifier",
+      "endpoint": "http://classifier:8001",
+      "manifest": null,
+      "enabled": true
+    },
+    "llm": {
+      "name": "llm",
+      "endpoint": "http://llm:8002",
+      "manifest": null,
+      "enabled": true
+    },
+    "tts": {
+      "name": "tts",
+      "endpoint": "http://tts:5050",
+      "manifest": null,
+      "enabled": true
+    },
+    "remote-save": {
+      "name": "remote-save",
+      "endpoint": "http://remote-save:7000",
+      "manifest": null,
+      "enabled": true
+    }
+  },
+  "pipeline": [
+    {
+      "service": "classifier",
+      "input_map": {
+        "sensor_data": "$sensor.data"
+      },
+      "on_failure": "skip",
+      "retry_count": 1,
+      "enabled": true
+    },
+    {
+      "service": "llm",
+      "input_map": {
+        "coffee_label": "$classifier.label",
+        "timestamp": "$sensor.timestamp"
+      },
+      "on_failure": "skip",
+      "retry_count": 1,
+      "enabled": true
+    },
+    {
+      "service": "tts",
+      "input_map": {
+        "text": "$llm.response"
+      },
+      "on_failure": "skip",
+      "retry_count": 1,
+      "enabled": true
+    },
+    {
+      "service": "remote-save",
+      "input_map": {
+        "name": "$classifier.label",
+        "coffee_type": "$classifier.label",
+        "confidence": "$classifier.confidence",
+        "text": "$llm.response",
+        "sensor_data": "$sensor.data"
+      },
+      "on_failure": "skip",
+      "retry_count": 1,
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a central service registry that manages registered pipeline services, fetches/validates manifests, provides parallel health checks, and persists the pipeline configuration to `data/pipeline.json`.

## Changes

### New files
- **`app/models/registry.py`**  Pydantic models: `ServiceRegistration`, `PipelineStep` (service, input_map, on_failure, retry_count, enabled), `PipelineConfig`
- **`app/registry.py`**  `ServiceRegistry` singleton: register/unregister services, manifest fetch+validation, parallel health checks, pipeline wiring validation (checks source references, required inputs, output availability), load/save to `data/pipeline.json`
- **`app/api/__init__.py`** + **`app/api/registry_routes.py`**  REST API routes:
  - `GET/POST/DELETE /api/registry/services`  CRUD for service registrations
  - `PATCH /api/registry/services/{name}/enabled`  toggle service
  - `POST /api/registry/services/{name}/refresh`  re-fetch manifest
  - `GET/PUT /api/registry/pipeline`  read/replace pipeline step config
  - `POST /api/registry/pipeline/validate`  static wiring validation
- **`data/pipeline.json`**  default config mirroring current hardcoded pipeline (classifier -> llm -> tts -> remote-save with input_map wiring)

### Modified files
- **`app/main.py`**  import + initialize registry on startup, mount registry API router
- **`app/config.py`**  add `PIPELINE_CONFIG_PATH` default

Part 2 of the dynamic pluggable pipeline feature (depends on PR #69).