### PR TITLE
feat: dynamic pipeline engine with input-map resolution

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -1,15 +1,17 @@
 """
 Pipeline orchestrator.
 
-Executes the full coffee pipeline:
-  1. Sensor      → collect 30s of IMU data
-  2. classifier  → classify coffee type
-  3. llm         → generate a witty statement
-  4. tts         → synthesize speech (WAV)
-  5. remote-save → save results + CSV to remote service (non-fatal)
+Executes the coffee pipeline in two phases:
+  1. **Sensor** (fixed first stage) — collect IMU data via mock/picoquake/serial
+  2. **Dynamic pipeline** — execute the configured service chain via
+     ``PipelineEngine``, which reads steps from the service registry.
 
-Each step passes its output to the next.  If a service is unavailable the
-pipeline stops at that step and reports what succeeded and what was skipped.
+Special modes handled before the dynamic pipeline:
+  - **Data collection** — if ``DATA_COLLECT_ENABLED``, save sensor data and skip
+    all downstream stages.
+
+Public functions ``run_pipeline()`` and ``run_pipeline_streaming()`` are
+backward-compatible wrappers used by ``main.py`` and the auto-trigger loop.
 """
 
 from __future__ import annotations
@@ -17,19 +19,15 @@ from __future__ import annotations
 import json
 import logging
 import os
-import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncGenerator
 
 from config import config
+from pipeline_engine import PipelineEngine
+from registry import registry
 from sensor.mock import mock_sensor
 from sensor.reader import read_sensor, read_sensor_streaming
-from services.classifier_client import ClassifierClient
-from services.llm_client import LLMClient
-from services.ollama_client import OllamaClient
-from services.tts_client import TTSClient
-from services.remote_save_client import RemoteSaveClient
 from services.training_data import save_recording
 
 logger = logging.getLogger("rpicoffee.pipeline")
@@ -37,16 +35,10 @@ logger = logging.getLogger("rpicoffee.pipeline")
 AUDIO_DIR = Path(os.environ.get("DATA_DIR", str(Path(__file__).resolve().parent.parent / "data"))) / "audio"
 
 
-def _cleanup_audio() -> None:
-    """Remove old WAV files from the audio directory."""
-    try:
-        for wav in AUDIO_DIR.glob("*.wav"):
-            try:
-                wav.unlink()
-            except OSError:
-                logger.warning("Could not delete %s", wav)
-    except OSError:
-        logger.warning("Could not list audio directory for cleanup")
+def _sse(event: str, data: Any) -> str:
+    """Format a Server-Sent Event message."""
+    payload = json.dumps(data) if not isinstance(data, str) else data
+    return f"event: {event}\ndata: {payload}\n\n"
 
 
 async def run_pipeline(
@@ -74,18 +66,6 @@ async def run_pipeline(
         audio_url       : str | None
         error           : str | None
     """
-    result: dict[str, Any] = {
-        "steps_completed": [],
-        "steps_skipped": [],
-        "sensor_samples": 0,
-        "sensor_data": None,
-        "label": None,
-        "confidence": None,
-        "text": None,
-        "audio_url": None,
-        "error": None,
-    }
-
     now = datetime.now().astimezone()
 
     # ── Step 0: Collect sensor data ──────────────────────────────
@@ -98,111 +78,33 @@ async def run_pipeline(
 
             sensor_data = await read_sensor(port=port)
 
-        result["sensor_samples"] = len(sensor_data)
-
         if not sensor_data:
-            result["error"] = "No sensor data collected"
-            return result
+            return _empty_result(error="No sensor data collected")
 
-        # Keep full raw data for remote save, downsample for the chart
         raw_sensor_data = sensor_data
-        step = max(1, len(sensor_data) // 300)
-        result["sensor_data"] = sensor_data[::step]
-
-        result["steps_completed"].append("sensor")
     except Exception as exc:
         logger.exception("Sensor read failed")
-        result["error"] = f"Sensor read failed: {exc}"
-        return result
+        return _empty_result(error=f"Sensor read failed: {exc}")
 
     # ── Data Collection Mode ──────────────────────────────────────
     if config.DATA_COLLECT_ENABLED and config.DATA_COLLECT_LABEL:
-        try:
-            filepath = save_recording(config.DATA_COLLECT_LABEL, raw_sensor_data)
-            result["label"] = config.DATA_COLLECT_LABEL
-            result["steps_completed"].append("data_collected")
-            result["data_collected"] = True
-            result["data_file"] = filepath
-            result["steps_skipped"].extend(["classifier", "llm", "tts", "remote-save"])
-            logger.info("Data collection: saved %d samples as '%s' → %s",
-                        len(raw_sensor_data), config.DATA_COLLECT_LABEL, filepath)
-            return result
-        except Exception as exc:
-            logger.exception("Data collection save failed")
-            result["error"] = f"Data collection save failed: {exc}"
-            return result
+        return await _data_collect(raw_sensor_data)
 
-    # ── Step 1: Classify via classifier ───────────────────────────
-    if on_progress:
-        on_progress("Classifying coffee type…")
-    classification = await ClassifierClient.classify(sensor_data)
+    # ── Dynamic pipeline stages ──────────────────────────────────
+    engine = PipelineEngine(registry)
+    ctx = await engine.execute(raw_sensor_data, now)
 
-    if classification is None:
-        result["steps_skipped"].append("classifier")
-        result["steps_skipped"].append("llm")
-        result["steps_skipped"].append("tts")
-        result["error"] = "Classification unavailable"
-    else:
-        result["label"] = classification["label"]
-        result["confidence"] = classification["confidence"]
-        result["steps_completed"].append("classifier")
+    # Build backward-compatible result dict
+    result = engine._build_summary(ctx)
+    result["sensor_samples"] = len(raw_sensor_data)
+    result["steps_completed"].insert(0, "sensor")
 
-    # ── Step 2: Generate text via llm ────────────────────────────
-    llm_text: str | None = None
-    if result["label"] is not None:
-        if on_progress:
-            on_progress(f"Generating text for {result['label']}…")
-        _llm = OllamaClient if config.LLM_BACKEND == "ollama" else LLMClient
-        llm_result = await _llm.generate(
-            coffee_label=result["label"],
-            timestamp=now,
-        )
-        if llm_result is None:
-            result["steps_skipped"].append("llm")
-            result["steps_skipped"].append("tts")
-            if not result["error"]:
-                result["error"] = "Text generation unavailable"
-        else:
-            llm_text = llm_result["response"]
-            result["text"] = llm_text
-            result["steps_completed"].append("llm")
-
-    # ── Step 3: Synthesize speech via tts ─────────────────────────
-    if llm_text is not None:
-        if on_progress:
-            on_progress("Synthesizing speech…")
-        audio_bytes = await TTSClient.synthesize(llm_text)
-        if audio_bytes is None:
-            result["steps_skipped"].append("tts")
-            if not result["error"]:
-                result["error"] = "Speech synthesis unavailable"
-        else:
-            _cleanup_audio()
-            audio_id = uuid.uuid4().hex[:12]
-            audio_path = AUDIO_DIR / f"{audio_id}.wav"
-            AUDIO_DIR.mkdir(parents=True, exist_ok=True)
-            audio_path.write_bytes(audio_bytes)
-            result["audio_url"] = f"/audio/{audio_id}.wav"
-            result["steps_completed"].append("tts")
-
-    # ── Step 4: Save results via remote save (always attempted) ──
-    if on_progress:
-        on_progress("Saving results…")
-    save_ok = await RemoteSaveClient.save(result, raw_sensor_data)
-    if save_ok:
-        result["steps_completed"].append("remote-save")
-    else:
-        result["steps_skipped"].append("remote-save")
-        logger.warning("Remote save skipped or failed – brew result still returned")
+    # Downsample for chart
+    step = max(1, len(raw_sensor_data) // 300)
+    result["sensor_data"] = raw_sensor_data[::step]
 
     logger.info("Pipeline complete: %s → %s", result["label"], result["audio_url"])
     return result
-
-
-def _sse(event: str, data: Any) -> str:
-    """Format a Server-Sent Event message."""
-    payload = json.dumps(data) if not isinstance(data, str) else data
-    return f"event: {event}\ndata: {payload}\n\n"
 
 
 async def run_pipeline_streaming(
@@ -221,21 +123,18 @@ async def run_pipeline_streaming(
         When True, skip the remote-save step.
 
     Events emitted:
-        sensor   – batch of sensor data points (many times)
-        status   – { message: str } progress updates
-        result   – final pipeline result dict (once, at end)
+        sensor          – batch of sensor data points (many times)
+        status          – { message: str } progress updates
+        step_start      – { service: name }
+        step_complete   – { service: name, result: ... }
+        step_error      – { service: name, error: ... }
+        step_skip       – { service: name, reason: ... }
+        classify        – legacy: { label, confidence }
+        text            – legacy: { text }
+        audio           – legacy: { audio_url }
+        pipeline_complete – full result summary
+        result          – final pipeline result dict (once, at end)
     """
-    result: dict[str, Any] = {
-        "steps_completed": [],
-        "steps_skipped": [],
-        "sensor_samples": 0,
-        "label": None,
-        "confidence": None,
-        "text": None,
-        "audio_url": None,
-        "error": None,
-    }
-
     now = datetime.now().astimezone()
 
     # ── Step 0: Stream sensor data ───────────────────────────────
@@ -250,115 +149,84 @@ async def run_pipeline_streaming(
 
         async for batch in read_sensor_streaming(port=port):
             all_sensor_data.extend(batch)
-            # Downsample batch for chart if large
             step = max(1, len(batch) // 20)
             yield _sse("sensor", batch[::step])
 
-        result["sensor_samples"] = len(all_sensor_data)
-
         if not all_sensor_data:
-            result["error"] = "No sensor data collected"
-            yield _sse("result", result)
+            yield _sse("result", _empty_result(error="No sensor data collected"))
             return
 
-        result["steps_completed"].append("sensor")
     except Exception as exc:
         logger.exception("Sensor read failed")
-        result["error"] = f"Sensor read failed: {exc}"
-        yield _sse("result", result)
+        yield _sse("result", _empty_result(error=f"Sensor read failed: {exc}"))
         return
 
     # ── Data Collection Mode ──────────────────────────────────────
     if config.DATA_COLLECT_ENABLED and config.DATA_COLLECT_LABEL:
-        try:
-            filepath = save_recording(config.DATA_COLLECT_LABEL, all_sensor_data)
-            result["label"] = config.DATA_COLLECT_LABEL
-            result["steps_completed"].append("data_collected")
-            result["data_collected"] = True
-            result["data_file"] = filepath
-            result["steps_skipped"].extend(["classifier", "llm", "tts", "remote-save"])
-            logger.info("Data collection: saved %d samples as '%s' → %s",
-                        len(all_sensor_data), config.DATA_COLLECT_LABEL, filepath)
-            yield _sse("data_collected", {
-                "label": config.DATA_COLLECT_LABEL,
-                "samples": len(all_sensor_data),
-                "file": filepath,
-            })
-            yield _sse("result", result)
-            return
-        except Exception as exc:
-            logger.exception("Data collection save failed")
-            result["error"] = f"Data collection save failed: {exc}"
-            yield _sse("result", result)
-            return
+        result = await _data_collect(all_sensor_data)
+        yield _sse("data_collected", {
+            "label": config.DATA_COLLECT_LABEL,
+            "samples": len(all_sensor_data),
+            "file": result.get("data_file"),
+        })
+        yield _sse("result", result)
+        return
 
-    # ── Step 1: Classify via classifier ───────────────────────────
-    yield _sse("status", {"message": "Classifying coffee type…"})
+    # ── Dynamic pipeline stages ──────────────────────────────────
+    engine = PipelineEngine(registry)
 
-    classification = await ClassifierClient.classify(all_sensor_data)
-
-    if classification is None:
-        result["steps_skipped"].extend(["classifier", "llm", "tts"])
-        result["error"] = "Classification unavailable"
-    else:
-        result["label"] = classification["label"]
-        result["confidence"] = classification["confidence"]
-        result["steps_completed"].append("classifier")
-        yield _sse("classify", {"label": classification["label"], "confidence": classification["confidence"]})
-
-    # ── Step 2: Generate text via llm ────────────────────────────
-    llm_text: str | None = None
-    if result["label"] is not None:
-        yield _sse("status", {"message": f"Generating text for {result['label']}…"})
-
-        _llm = OllamaClient if config.LLM_BACKEND == "ollama" else LLMClient
-        llm_result = await _llm.generate(
-            coffee_label=result["label"],
-            timestamp=now,
-        )
-
-        if llm_result is None:
-            result["steps_skipped"].extend(["llm", "tts"])
-            if not result["error"]:
-                result["error"] = "Text generation unavailable"
-        else:
-            llm_text = llm_result["response"]
-            result["text"] = llm_text
-            result["steps_completed"].append("llm")
-            yield _sse("text", {"text": llm_text})
-
-    # ── Step 3: Synthesize speech via tts ─────────────────────────
-    if llm_text is not None:
-        yield _sse("status", {"message": "Synthesizing speech…"})
-
-        audio_bytes = await TTSClient.synthesize(llm_text)
-
-        if audio_bytes is None:
-            result["steps_skipped"].append("tts")
-            if not result["error"]:
-                result["error"] = "Speech synthesis unavailable"
-        else:
-            _cleanup_audio()
-            audio_id = uuid.uuid4().hex[:12]
-            audio_path = AUDIO_DIR / f"{audio_id}.wav"
-            AUDIO_DIR.mkdir(parents=True, exist_ok=True)
-            audio_path.write_bytes(audio_bytes)
-            result["audio_url"] = f"/audio/{audio_id}.wav"
-            result["steps_completed"].append("tts")
-            yield _sse("audio", {"audio_url": result["audio_url"]})
-
-    # ── Step 4: Save results via remote save (unless skipped) ────
+    # If skip_save is requested, temporarily disable the remote-save step
     if skip_save:
-        result["steps_skipped"].append("remote-save")
-        logger.info("Remote save skipped (test mode)")
-    else:
-        yield _sse("status", {"message": "Saving results…"})
-        save_ok = await RemoteSaveClient.save(result, all_sensor_data)
-        if save_ok:
-            result["steps_completed"].append("remote-save")
-        else:
-            result["steps_skipped"].append("remote-save")
-            logger.warning("Remote save skipped or failed – brew result still returned")
+        registry.set_enabled("remote-save", False)
 
-    logger.info("Pipeline complete: %s → %s", result["label"], result["audio_url"])
-    yield _sse("result", result)
+    final_summary: dict[str, Any] | None = None
+    try:
+        async for event in engine.execute_streaming(all_sensor_data, now):
+            yield _sse(event["event"], event["data"])
+            if event["event"] == "pipeline_complete":
+                final_summary = event["data"]
+    finally:
+        if skip_save:
+            registry.set_enabled("remote-save", True)
+
+    # Emit legacy result event for full backward compatibility
+    if final_summary is not None:
+        final_summary["sensor_samples"] = len(all_sensor_data)
+        final_summary.setdefault("steps_completed", []).insert(0, "sensor")
+        yield _sse("result", final_summary)
+
+    logger.info("Pipeline streaming complete")
+
+
+def _empty_result(error: str | None = None) -> dict[str, Any]:
+    """Return an empty result dict with optional error."""
+    return {
+        "steps_completed": [],
+        "steps_skipped": [],
+        "sensor_samples": 0,
+        "sensor_data": None,
+        "label": None,
+        "confidence": None,
+        "text": None,
+        "audio_url": None,
+        "error": error,
+    }
+
+
+async def _data_collect(raw_sensor_data: list[dict[str, float]]) -> dict[str, Any]:
+    """Handle data collection mode: save sensor data and skip pipeline."""
+    result = _empty_result()
+    try:
+        filepath = save_recording(config.DATA_COLLECT_LABEL, raw_sensor_data)
+        result["label"] = config.DATA_COLLECT_LABEL
+        result["sensor_samples"] = len(raw_sensor_data)
+        result["steps_completed"] = ["sensor", "data_collected"]
+        result["data_collected"] = True
+        result["data_file"] = filepath
+        result["steps_skipped"] = ["classifier", "llm", "tts", "remote-save"]
+        logger.info("Data collection: saved %d samples as '%s' → %s",
+                    len(raw_sensor_data), config.DATA_COLLECT_LABEL, filepath)
+    except Exception as exc:
+        logger.exception("Data collection save failed")
+        result["error"] = f"Data collection save failed: {exc}"
+    return result

--- a/app/pipeline_engine.py
+++ b/app/pipeline_engine.py
@@ -1,0 +1,339 @@
+"""Dynamic pipeline engine.
+
+Reads the pipeline configuration from the service registry and executes
+each step sequentially, resolving ``$sensor.*`` and ``$<service>.*``
+input-map references to actual data from previous steps.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any, AsyncGenerator
+
+from models.manifest import ServiceManifest
+from models.registry import PipelineStep
+from pipeline_executor import ServiceCallError, call_service
+from registry import ServiceRegistry
+
+logger = logging.getLogger(__name__)
+
+AUDIO_DIR = Path(os.environ.get("DATA_DIR", str(Path(__file__).resolve().parent.parent / "data"))) / "audio"
+
+
+class PipelineContext:
+    """Carries data between pipeline steps."""
+
+    def __init__(
+        self,
+        sensor_data: list[dict[str, float]],
+        sensor_timestamp: datetime,
+    ) -> None:
+        self.sensor_data = sensor_data
+        self.sensor_timestamp = sensor_timestamp
+        self.results: dict[str, dict[str, Any]] = {}
+        self.errors: dict[str, str] = {}
+        self.skipped: list[str] = []
+        self.halted: bool = False
+
+    def resolve_ref(self, ref: str) -> Any:
+        """Resolve a ``$source.key`` reference against the context.
+
+        Supported reference forms:
+          - ``$sensor.data``       → raw sensor data list
+          - ``$sensor.timestamp``  → ISO-formatted sensor timestamp
+          - ``$<service>.<key>``   → output from a previous pipeline step
+        """
+        if not ref.startswith("$"):
+            return ref
+
+        parts = ref.lstrip("$").split(".", 1)
+        if len(parts) != 2:
+            return None
+
+        source, key = parts
+
+        if source == "sensor":
+            if key == "data":
+                return self.sensor_data
+            if key == "timestamp":
+                return self.sensor_timestamp.isoformat()
+            return None
+
+        step_result = self.results.get(source)
+        if step_result is None:
+            return None
+        return step_result.get(key)
+
+
+class PipelineEngine:
+    """Executes a dynamic pipeline defined in the service registry."""
+
+    def __init__(self, registry: ServiceRegistry) -> None:
+        self._registry = registry
+
+    async def execute(
+        self,
+        sensor_data: list[dict[str, float]],
+        sensor_timestamp: datetime,
+    ) -> PipelineContext:
+        """Run all enabled pipeline steps sequentially.
+
+        Returns the populated context with results, errors, and skipped steps.
+        """
+        ctx = PipelineContext(sensor_data, sensor_timestamp)
+
+        for step in self._registry.get_pipeline():
+            if not step.enabled:
+                ctx.skipped.append(step.service)
+                continue
+            if ctx.halted:
+                ctx.skipped.append(step.service)
+                continue
+
+            await self._execute_step(step, ctx)
+
+        return ctx
+
+    async def execute_streaming(
+        self,
+        sensor_data: list[dict[str, float]],
+        sensor_timestamp: datetime,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Run all enabled pipeline steps, yielding SSE-ready event dicts.
+
+        Events yielded per step:
+          ``step_start``    — ``{"service": name}``
+          ``step_complete`` — ``{"service": name, "result": ...}``
+          ``step_error``    — ``{"service": name, "error": ...}``
+          ``step_skip``     — ``{"service": name, "reason": ...}``
+
+        Also emits legacy event names for known services to maintain
+        backward compatibility with the kiosk UI:
+          ``classify``, ``text``, ``audio``
+
+        Final event:
+          ``pipeline_complete`` — full result summary
+        """
+        ctx = PipelineContext(sensor_data, sensor_timestamp)
+
+        for step in self._registry.get_pipeline():
+            if not step.enabled:
+                ctx.skipped.append(step.service)
+                yield {"event": "step_skip", "data": {"service": step.service, "reason": "disabled"}}
+                continue
+            if ctx.halted:
+                ctx.skipped.append(step.service)
+                yield {"event": "step_skip", "data": {"service": step.service, "reason": "halted"}}
+                continue
+
+            yield {"event": "step_start", "data": {"service": step.service}}
+            yield {"event": "status", "data": {"message": f"Running {step.service}…"}}
+
+            error = await self._execute_step(step, ctx)
+
+            if error:
+                yield {"event": "step_error", "data": {"service": step.service, "error": error}}
+            else:
+                step_result = ctx.results.get(step.service, {})
+                yield {"event": "step_complete", "data": {"service": step.service, "result": step_result}}
+
+                # Emit legacy events for backward compatibility
+                for legacy_event in self._legacy_events(step.service, step_result, ctx):
+                    yield legacy_event
+
+        # Final summary event
+        yield {"event": "pipeline_complete", "data": self._build_summary(ctx)}
+
+    # ── Private helpers ──────────────────────────────────────────
+
+    async def _execute_step(
+        self,
+        step: PipelineStep,
+        ctx: PipelineContext,
+    ) -> str | None:
+        """Execute a single step, handling retries and failure policies.
+
+        Returns None on success, or an error message string on failure.
+        """
+        reg = self._registry.get(step.service)
+        if not reg or not reg.manifest:
+            reason = f"Service '{step.service}' not registered or has no manifest"
+            self._apply_failure(step, ctx, reason)
+            return reason
+
+        if not reg.enabled:
+            ctx.skipped.append(step.service)
+            return None
+
+        # Resolve input_map to actual values
+        payload = self._resolve_inputs(step, ctx)
+        if payload is None:
+            reason = f"Missing required inputs for '{step.service}'"
+            self._apply_failure(step, ctx, reason)
+            return reason
+
+        manifest = reg.manifest
+        ep = manifest.endpoints.execute
+        max_attempts = step.retry_count if step.on_failure == "retry" else 1
+
+        last_error = ""
+        for attempt in range(1, max_attempts + 1):
+            try:
+                result = await call_service(
+                    endpoint=reg.endpoint,
+                    method=ep.method,
+                    path=ep.path,
+                    payload=payload,
+                )
+
+                # Handle binary responses (e.g. TTS audio)
+                if isinstance(result, bytes):
+                    result = self._handle_binary(step.service, result, manifest)
+
+                ctx.results[step.service] = result
+                logger.info("Step '%s' completed (attempt %d)", step.service, attempt)
+                return None
+
+            except ServiceCallError as exc:
+                last_error = exc.message
+                logger.warning(
+                    "Step '%s' attempt %d/%d failed: %s",
+                    step.service, attempt, max_attempts, exc.message,
+                )
+
+        # All attempts exhausted
+        self._apply_failure(step, ctx, last_error)
+        return last_error
+
+    def _resolve_inputs(
+        self,
+        step: PipelineStep,
+        ctx: PipelineContext,
+    ) -> dict[str, Any] | None:
+        """Resolve all input_map references for a step.
+
+        Returns the payload dict or None if a required input is missing.
+        """
+        reg = self._registry.get(step.service)
+        if not reg or not reg.manifest:
+            return None
+
+        payload: dict[str, Any] = {}
+        required_names = {inp.name for inp in reg.manifest.inputs if inp.required}
+
+        for input_name, source_ref in step.input_map.items():
+            value = ctx.resolve_ref(source_ref)
+            if value is not None:
+                payload[input_name] = value
+            elif input_name in required_names:
+                logger.warning(
+                    "Step '%s': required input '%s' (ref '%s') resolved to None",
+                    step.service, input_name, source_ref,
+                )
+                return None
+
+        return payload
+
+    def _apply_failure(
+        self,
+        step: PipelineStep,
+        ctx: PipelineContext,
+        error: str,
+    ) -> None:
+        """Apply the step's failure policy."""
+        ctx.errors[step.service] = error
+        if step.on_failure == "halt":
+            ctx.halted = True
+            logger.error("Step '%s' failed with halt policy — stopping pipeline: %s",
+                         step.service, error)
+        else:
+            ctx.skipped.append(step.service)
+            logger.warning("Step '%s' failed with skip policy — continuing: %s",
+                           step.service, error)
+
+    def _handle_binary(
+        self,
+        service_name: str,
+        data: bytes,
+        manifest: ServiceManifest,
+    ) -> dict[str, Any]:
+        """Handle binary response (save to disk if audio, return file URL)."""
+        # Check if manifest declares a 'binary' output
+        has_audio = any(o.type == "binary" and "audio" in o.name for o in manifest.outputs)
+        if has_audio and data:
+            self._cleanup_audio()
+            audio_id = uuid.uuid4().hex[:12]
+            audio_path = AUDIO_DIR / f"{audio_id}.wav"
+            AUDIO_DIR.mkdir(parents=True, exist_ok=True)
+            audio_path.write_bytes(data)
+            return {"audio": data, "audio_url": f"/audio/{audio_id}.wav"}
+        return {"data": data}
+
+    @staticmethod
+    def _cleanup_audio() -> None:
+        """Remove old WAV files."""
+        try:
+            for wav in AUDIO_DIR.glob("*.wav"):
+                try:
+                    wav.unlink()
+                except OSError:
+                    pass
+        except OSError:
+            pass
+
+    def _legacy_events(
+        self,
+        service_name: str,
+        result: dict[str, Any],
+        ctx: PipelineContext,
+    ) -> list[dict[str, Any]]:
+        """Emit legacy SSE events for known services (backward compat)."""
+        events: list[dict[str, Any]] = []
+        if service_name == "classifier" and "label" in result:
+            events.append({
+                "event": "classify",
+                "data": {"label": result["label"], "confidence": result.get("confidence")},
+            })
+        elif service_name in ("llm", "llm-ollama") and "response" in result:
+            events.append({"event": "text", "data": {"text": result["response"]}})
+        elif service_name == "tts" and "audio_url" in result:
+            events.append({"event": "audio", "data": {"audio_url": result["audio_url"]}})
+        return events
+
+    def _build_summary(self, ctx: PipelineContext) -> dict[str, Any]:
+        """Build the final pipeline result summary (backward-compatible)."""
+        summary: dict[str, Any] = {
+            "steps_completed": list(ctx.results.keys()),
+            "steps_skipped": ctx.skipped,
+            "sensor_samples": len(ctx.sensor_data),
+            "label": None,
+            "confidence": None,
+            "text": None,
+            "audio_url": None,
+            "error": None,
+        }
+
+        # Pull out well-known values from step results
+        classifier = ctx.results.get("classifier", {})
+        summary["label"] = classifier.get("label")
+        summary["confidence"] = classifier.get("confidence")
+
+        for name in ("llm", "llm-ollama"):
+            llm = ctx.results.get(name, {})
+            if llm.get("response"):
+                summary["text"] = llm["response"]
+                break
+
+        tts = ctx.results.get("tts", {})
+        summary["audio_url"] = tts.get("audio_url")
+
+        # First error encountered
+        if ctx.errors:
+            summary["error"] = next(iter(ctx.errors.values()))
+
+        return summary

--- a/app/pipeline_executor.py
+++ b/app/pipeline_executor.py
@@ -1,0 +1,80 @@
+"""Thin async HTTP caller for pipeline service execution.
+
+Handles both JSON and binary (e.g. TTS audio) responses.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = 30.0
+
+
+class ServiceCallError(Exception):
+    """Raised when a service call fails."""
+
+    def __init__(self, service: str, message: str) -> None:
+        self.service = service
+        self.message = message
+        super().__init__(f"{service}: {message}")
+
+
+async def call_service(
+    endpoint: str,
+    method: str,
+    path: str,
+    payload: dict[str, Any],
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> dict[str, Any] | bytes:
+    """Call a service endpoint and return the response.
+
+    Parameters
+    ----------
+    endpoint : str
+        Base URL of the service (e.g. ``http://classifier:8001``).
+    method : str
+        HTTP method (``GET``, ``POST``, etc.).
+    path : str
+        URL path relative to the service root (e.g. ``/classify``).
+    payload : dict
+        JSON body to send (ignored for GET requests).
+    timeout : float
+        Request timeout in seconds.
+
+    Returns
+    -------
+    dict or bytes
+        JSON-decoded dict for ``application/json`` responses,
+        raw bytes for binary responses (e.g. audio).
+
+    Raises
+    ------
+    ServiceCallError
+        On HTTP errors or connection failures.
+    """
+    url = f"{endpoint.rstrip('/')}{path}"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if method.upper() == "GET":
+                resp = await client.get(url)
+            else:
+                resp = await client.request(method.upper(), url, json=payload)
+            resp.raise_for_status()
+
+            content_type = resp.headers.get("content-type", "")
+            if "application/json" in content_type:
+                return resp.json()
+            # Binary response (e.g. WAV audio from TTS)
+            return resp.content
+    except httpx.HTTPStatusError as exc:
+        raise ServiceCallError(
+            url,
+            f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
+        ) from exc
+    except Exception as exc:
+        raise ServiceCallError(url, str(exc)) from exc

--- a/services/llm-ollama/main.py
+++ b/services/llm-ollama/main.py
@@ -159,7 +159,9 @@ def _tts_clean(text: str) -> str:
 # ── Request / Response models ────────────────────────────────────
 
 class GenerateRequest(BaseModel):
-    prompt: str = Field(..., min_length=1)
+    prompt: str | None = Field(None, min_length=1)
+    coffee_label: str | None = Field(None, description="Coffee type label — builds prompt automatically")
+    timestamp: str | None = Field(None, description="ISO-8601 timestamp — used with coffee_label")
     system: str | None = None
     max_tokens: int | None = None
     temperature: float | None = None
@@ -280,8 +282,14 @@ async def health():
 
 @app.post("/generate")
 async def generate(req: GenerateRequest):
-    if not req.prompt:
-        raise HTTPException(status_code=400, detail="prompt is required")
+    # Accept either a raw prompt or structured coffee_label + timestamp
+    user_msg = req.prompt
+    if not user_msg:
+        if req.coffee_label:
+            ts = req.timestamp or datetime.now().astimezone().isoformat()
+            user_msg = f"Write a statement about {req.coffee_label.title()} at {ts}"
+        else:
+            raise HTTPException(status_code=400, detail="prompt or coffee_label is required")
 
     max_tokens = req.max_tokens if req.max_tokens is not None else _runtime["LLM_MAX_TOKENS"]
     temperature = req.temperature if req.temperature is not None else _runtime["LLM_TEMPERATURE"]
@@ -293,7 +301,7 @@ async def generate(req: GenerateRequest):
 
     try:
         raw_text, metadata = await _ollama_generate(
-            req.prompt,
+            user_msg,
             system=system,
             max_tokens=max_tokens,
             temperature=temperature,
@@ -316,7 +324,7 @@ async def generate(req: GenerateRequest):
     tokens_per_s = (eval_count / (eval_ns / 1e9)) if eval_ns else 0
 
     # Post-process
-    day_name, time_24h = _parse_timestamp(req.prompt)
+    day_name, time_24h = _parse_timestamp(user_msg)
     text = raw_text.strip()
     text = _postprocess(text, day_name, time_24h)
     if tts:

--- a/services/llm/server.py
+++ b/services/llm/server.py
@@ -191,7 +191,9 @@ def build_prompt(user_msg: str, system: str | None = None) -> str:
 # ── Request / Response models ────────────────────────────────────
 
 class GenerateRequest(BaseModel):
-    prompt: str = Field(..., min_length=1)
+    prompt: str | None = Field(None, min_length=1)
+    coffee_label: str | None = Field(None, description="Coffee type label — builds prompt automatically")
+    timestamp: str | None = Field(None, description="ISO-8601 timestamp — used with coffee_label")
     system: str | None = None
     max_tokens: int | None = None
     temperature: float | None = None
@@ -262,8 +264,14 @@ async def health():
 
 @app.post("/generate")
 async def generate(req: GenerateRequest):
-    if not req.prompt:
-        raise HTTPException(status_code=400, detail="prompt is required")
+    # Accept either a raw prompt or structured coffee_label + timestamp
+    user_msg = req.prompt
+    if not user_msg:
+        if req.coffee_label:
+            ts = req.timestamp or datetime.now().astimezone().isoformat()
+            user_msg = f"Write a statement about {req.coffee_label.title()} at {ts}"
+        else:
+            raise HTTPException(status_code=400, detail="prompt or coffee_label is required")
 
     # Resolve from runtime defaults when request omits a value
     max_tokens = req.max_tokens if req.max_tokens is not None else _runtime["LLM_MAX_TOKENS"]
@@ -272,8 +280,8 @@ async def generate(req: GenerateRequest):
     tts = req.tts if req.tts is not None else _runtime["LLM_TTS"]
     system = req.system if req.system is not None else _runtime["LLM_SYSTEM_MESSAGE"]
 
-    day_name, time_24h, _ = parse_timestamp(req.prompt)
-    prompt = build_prompt(req.prompt, system=system)
+    day_name, time_24h, _ = parse_timestamp(user_msg)
+    prompt = build_prompt(user_msg, system=system)
     model.reset()
     t0 = time.perf_counter()
     result = model(

--- a/services/remote-save/app.py
+++ b/services/remote-save/app.py
@@ -100,16 +100,20 @@ def _env(name: str) -> str:
 # ── Request / Response models ───────────────────────────────────────────────
 class SaveRequest(BaseModel):
     name: str = Field(..., description="Record name")
-    data: str = Field(..., description="Text content to store in the record")
-    text: str = Field(..., description="Text content for the jenssch_text column")
-    confidence: float = Field(..., description="Classification confidence score")
+    data: str = Field("", description="Text content to store in the record")
+    text: str = Field("", description="Text content for the jenssch_text column")
+    confidence: float = Field(0.0, description="Classification confidence score")
     coffee_type: str = Field(
         ...,
         description="Coffee type (Black, Espresso, or Cappuccino)",
     )
+    sensor_data: list[dict[str, Any]] | None = Field(
+        None,
+        description="Raw sensor data array — service converts to CSV + base64 automatically",
+    )
     file_content: str | None = Field(
         None,
-        description="Base64-encoded file bytes to upload to the file column",
+        description="Base64-encoded file bytes to upload to the file column (legacy)",
     )
     file_name: str | None = Field(
         None,
@@ -192,6 +196,23 @@ def upload_file(
     with file_path.open("rb") as payload:
         response = requests.patch(url, data=payload, headers=headers, timeout=120)
     response.raise_for_status()
+
+
+# ── CSV helpers ─────────────────────────────────────────────────────────────
+
+_CSV_COLUMNS = ["label", "elapsed_s", "acc_x", "acc_y", "acc_z", "gyro_x", "gyro_y", "gyro_z"]
+
+
+def _sensor_data_to_csv(sensor_data: list[dict[str, Any]], label: str) -> str:
+    """Convert raw sensor dicts to a CSV string with the classification label."""
+    import csv
+    import io
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=_CSV_COLUMNS, extrasaction="ignore")
+    writer.writeheader()
+    for row in sensor_data:
+        writer.writerow({"label": label, **row})
+    return buf.getvalue()
 
 
 # ── Endpoints ───────────────────────────────────────────────────────────────
@@ -295,11 +316,23 @@ def save(req: SaveRequest) -> SaveResponse:
             detail=f"Failed to create Dataverse record: {exc}",
         ) from exc
 
-    # Upload file content if provided
-    if req.file_content:
-        file_name = req.file_name or f"{req.name}.txt"
+    # Upload file content if provided (or auto-generate from sensor_data)
+    file_content = req.file_content
+    file_name = req.file_name
+
+    if not file_content and req.sensor_data:
+        csv_str = _sensor_data_to_csv(req.sensor_data, coffee_key)
+        data_field = csv_str  # also store CSV in the data column
+        file_content = base64.b64encode(csv_str.encode("utf-8")).decode("ascii")
+        file_name = file_name or f"{req.name}.csv"
+        # Update data column with CSV if it was empty
+        if not req.data:
+            record_payload[col_data] = data_field
+
+    if file_content:
+        file_name = file_name or f"{req.name}.txt"
         try:
-            file_bytes = base64.b64decode(req.file_content)
+            file_bytes = base64.b64decode(file_content)
         except Exception as exc:
             raise HTTPException(
                 status_code=400,


### PR DESCRIPTION
## Summary
Replaces the hardcoded pipeline steps in `app/pipeline.py` with a dynamic `PipelineEngine` that reads step configuration from the service registry and executes them sequentially, resolving `.*` and `$<service>.*` input-map references.

## Changes

### New files
- **`app/pipeline_engine.py`** u2014 `PipelineEngine` class:
  - `execute()` runs all enabled steps sequentially, returns `PipelineContext` with results, errors, skipped steps
  - `execute_streaming()` yields SSE-ready event dicts per step (`step_start`, `step_complete`, `step_error`, `step_skip`, `pipeline_complete`)
  - Input-map resolution: `.data`, `.timestamp`, `$<service>.<key>`
  - Per-step failure policies: `skip` (log + continue), `halt` (stop pipeline), `retry` (N attempts)
  - Binary response handling: auto-saves audio files to disk
  - Legacy SSE event emission: `classify`, `text`, `audio` for backward compat
  - `PipelineContext` class: carries sensor data, step results, errors, and halted state

- **`app/pipeline_executor.py`** u2014 Thin async HTTP caller:
  - `call_service()` handles both JSON and binary responses
  - Raises `ServiceCallError` with structured error info

### Modified files
- **`app/pipeline.py`** u2014 Refactored to delegate to `PipelineEngine`:
  - `run_pipeline()` collects sensor data, then delegates to `engine.execute()`
  - `run_pipeline_streaming()` streams sensor data, then delegates to `engine.execute_streaming()`
  - Data collection mode and force-mock remain in pipeline.py (special modes)
  - Removed direct imports of all service clients (now handled by engine)

- **`services/llm/server.py`** u2014 Accept structured inputs:
  - `GenerateRequest.prompt` is now optional
  - Added `coffee_label` + `timestamp` fields: service builds prompt internally
  - Backward compat: raw `prompt` still works

- **`services/llm-ollama/main.py`** u2014 Same structured input support as llm

- **`services/remote-save/app.py`** u2014 Accept raw sensor data:
  - Added `sensor_data` field (array): service does CSV + base64 conversion internally
  - `data`, `text`, `confidence` fields now optional (with defaults)
  - Backward compat: existing `file_content` (pre-encoded) still works

Part 3 of the dynamic pluggable pipeline feature (depends on PR #70).